### PR TITLE
Add support task_args, task_kwargs and task_name

### DIFF
--- a/django_celery_results/admin.py
+++ b/django_celery_results/admin.py
@@ -22,6 +22,13 @@ class TaskResultAdmin(admin.ModelAdmin):
             ),
             'classes': ('extrapretty', 'wide')
         }),
+        ('Invocation', {
+            'fields': (
+                'task_name',
+                'task_args',
+                'task_kwargs',
+            )
+        }),
         ('Result', {
             'fields': (
                 'result',

--- a/django_celery_results/backends/database.py
+++ b/django_celery_results/backends/database.py
@@ -21,12 +21,15 @@ class DatabaseBackend(BaseDictBackend):
         _, _, meta = self.encode_content({
             'children': self.current_task_children(request),
         })
+        task_name = getattr(request, 'task', '') if request else ''
+        task_args = getattr(request, 'args', '') if request else ''
+        task_kwargs = getattr(request, 'kargs', '') if request else ''
 
         self.TaskModel._default_manager.store_result(
             content_type, content_encoding,
             task_id, result, status,
-            traceback=traceback,
-            meta=meta,
+            task_name=task_name, task_args=task_args,
+            task_kwargs=task_kwargs, traceback=traceback, meta=meta,
         )
         return result
 

--- a/django_celery_results/backends/database.py
+++ b/django_celery_results/backends/database.py
@@ -23,7 +23,7 @@ class DatabaseBackend(BaseDictBackend):
         })
         task_name = getattr(request, 'task', '') if request else ''
         task_args = getattr(request, 'args', '') if request else ''
-        task_kwargs = getattr(request, 'kargs', '') if request else ''
+        task_kwargs = getattr(request, 'kwargs', '') if request else ''
 
         self.TaskModel._default_manager.store_result(
             content_type, content_encoding,

--- a/django_celery_results/managers.py
+++ b/django_celery_results/managers.py
@@ -86,7 +86,8 @@ class TaskResultManager(models.Manager):
     @transaction_retry(max_retries=2)
     def store_result(self, content_type, content_encoding,
                      task_id, result, status,
-                     traceback=None, meta=None):
+                     task_name='', task_args='', task_kwargs='',
+                     traceback=None, meta=None,):
         """Store the result and status of a task.
 
         Arguments:
@@ -97,16 +98,15 @@ class TaskResultManager(models.Manager):
                 or an exception instance raised by the task.
             status (str): Task status.  See :mod:`celery.states` for a list of
                 possible status values.
+            task_name (str): name of task.
+            task_args (str): arguments of task.
+            task_kwargs (str): keyword arguments of task.
 
         Keyword Arguments:
             traceback (str): The traceback string taken at the point of
                 exception (only passed if the task failed).
             meta (str): Serialized result meta data (this contains e.g.
                 children).
-            exception_retry_count (int): How many times to retry by
-                transaction rollback on exception.  This could
-                happen in a race condition if another worker is trying to
-                create the same task.  The default is to retry twice.
         """
         fields = {
             'status': status,
@@ -115,6 +115,9 @@ class TaskResultManager(models.Manager):
             'meta': meta,
             'content_encoding': content_encoding,
             'content_type': content_type,
+            'task_name': task_name,
+            'task_args': task_args,
+            'task_kwargs': task_kwargs
         }
         obj, created = self.get_or_create(task_id=task_id, defaults=fields)
         if not created:

--- a/django_celery_results/migrations/0002_add_task_result_task_args.py
+++ b/django_celery_results/migrations/0002_add_task_result_task_args.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('celery_results', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='taskresult',
+            name='task_args',
+            field=models.TextField(blank=True, default='', verbose_name='task arguments'),
+        ),
+        migrations.AddField(
+            model_name='taskresult',
+            name='task_kwargs',
+            field=models.TextField(blank=True, default='', verbose_name='task keyword arguments'),
+        ),
+        migrations.AddField(
+            model_name='taskresult',
+            name='task_name',
+            field=models.CharField(blank=True, default='', max_length=255, verbose_name='task name'),
+        ),
+    ]

--- a/django_celery_results/models.py
+++ b/django_celery_results/models.py
@@ -32,6 +32,9 @@ class TaskResult(models.Model):
     content_encoding = models.CharField(
         _('content encoding'), max_length=64,
     )
+    task_name = models.CharField( _('task name'),blank=True, default='', max_length=255)
+    task_args = models.TextField(_('task arguments'), blank=True, default='')
+    task_kwargs = models.TextField(_('task keyword arguments'), blank=True, default='')
     result = models.TextField(null=True, default=None, editable=False)
     date_done = models.DateTimeField(_('done at'), auto_now=True)
     traceback = models.TextField(_('traceback'), blank=True, null=True)


### PR DESCRIPTION
With this fix, detailed information on the task will be available. ( name, args, kwargs )
It based on with reference to the following PR. ( some improvements)
* https://github.com/celery/django-celery-results/pull/14/files