### PR TITLE
Use celery's b64decode and b64encode

### DIFF
--- a/django_celery_results/backends/database.py
+++ b/django_celery_results/backends/database.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
-from base64 import b64encode, b64decode
-
 from celery.backends.base import BaseDictBackend
+from celery.utils.serialization import b64encode, b64decode
 
 from ..models import TaskResult
 


### PR DESCRIPTION
The original functions (from `base64`) return `bytes` objects on Python 3. Django 2 does not encode them to `str` before putting them in the database, resulting in strings like `"b'gAJ9cQBYCAAAAGNoaWxkcmVucQFdcQJzLg=='"` ending up in the database. Those in turn cannot be correctly `b64decode`-d and unpickled.

Using `celery`'s wrapper functions solves that problem.