### PR TITLE
Admin filters

### DIFF
--- a/django_celery_results/admin.py
+++ b/django_celery_results/admin.py
@@ -10,6 +10,7 @@ class TaskResultAdmin(admin.ModelAdmin):
     """Admin-interface for results of tasks."""
 
     model = TaskResult
+    date_hierarchy = 'date_done'
     list_display = ('task_name', 'task_id', 'date_done', 'status')
     list_filter = ('status', 'date_done', 'task_name',)
     readonly_fields = ('date_done', 'result', 'hidden', 'meta')

--- a/django_celery_results/admin.py
+++ b/django_celery_results/admin.py
@@ -14,6 +14,7 @@ class TaskResultAdmin(admin.ModelAdmin):
     list_display = ('task_name', 'task_id', 'date_done', 'status')
     list_filter = ('status', 'date_done', 'task_name',)
     readonly_fields = ('date_done', 'result', 'hidden', 'meta')
+    search_fields = ('task_name', 'task_id', 'status')
     fieldsets = (
         (None, {
             'fields': (

--- a/django_celery_results/admin.py
+++ b/django_celery_results/admin.py
@@ -11,7 +11,7 @@ class TaskResultAdmin(admin.ModelAdmin):
 
     model = TaskResult
     list_display = ('task_name', 'task_id', 'date_done', 'status')
-    list_filter = ('status', 'date_done')
+    list_filter = ('status', 'date_done', 'task_name',)
     readonly_fields = ('date_done', 'result', 'hidden', 'meta')
     fieldsets = (
         (None, {


### PR DESCRIPTION
Some convenience additions to the list view to allow people to more easily skim through large result sets:

- Date hierarchy for browsing by date more easily over a longer period of time
- Filter by task name (eg. to see results of a daily task amongst a large list of those run every minute)
- Search by task details (eg. to find the results of a single item you know ran, or to search all "category.taskname failure" without clicking multiple filters)