### PR TITLE
Admin list

### DIFF
--- a/django_celery_results/admin.py
+++ b/django_celery_results/admin.py
@@ -10,14 +10,14 @@ class TaskResultAdmin(admin.ModelAdmin):
     """Admin-interface for results of tasks."""
 
     model = TaskResult
-    list_display = ('task_name', 'task_id', 'date_done', 'status')
+    list_display = ('task_id', 'task_name', 'date_done', 'status')
     list_filter = ('status', 'date_done')
     readonly_fields = ('date_done', 'result', 'hidden', 'meta')
     fieldsets = (
         (None, {
             'fields': (
-                'task_name',
                 'task_id',
+                'task_name',
                 'status',
                 'content_type',
                 'content_encoding',

--- a/django_celery_results/models.py
+++ b/django_celery_results/models.py
@@ -38,6 +38,8 @@ class TaskResult(models.Model):
     class Meta:
         """Table information."""
 
+        ordering = ['-date_done']
+
         verbose_name = _('task result')
         verbose_name_plural = _('task results')
 


### PR DESCRIPTION
Some minor tweaks to the list view that make life easier when there are results that tend to be clustered together in large quantities:

- Default ordering to date descending
- Have the first field / linked field in the list be the Task ID (when you click you are clicking to view that task, not anything about the task name, which is often repeated hundreds of times in a row)