### PR TITLE
Add ALLOW_EDITS Django setting

### DIFF
--- a/django_celery_results/admin.py
+++ b/django_celery_results/admin.py
@@ -3,6 +3,13 @@ from __future__ import absolute_import, unicode_literals
 
 from django.contrib import admin
 
+from django.conf import settings
+try:
+    ALLOW_EDITS = settings.DJANGO_CELERY_RESULTS['ALLOW_EDITS']
+except (AttributeError, KeyError) as e:
+    ALLOW_EDITS = True
+    pass
+
 from .models import TaskResult
 
 
@@ -43,5 +50,12 @@ class TaskResultAdmin(admin.ModelAdmin):
         }),
     )
 
+    def get_readonly_fields(self, request, obj=None):
+        if ALLOW_EDITS:
+            return self.readonly_fields
+        else:
+            return list(set(
+                [field.name for field in self.opts.local_fields]
+            ))
 
 admin.site.register(TaskResult, TaskResultAdmin)


### PR DESCRIPTION
Since this is primarily for viewing results, in our use case I don't really find it makes sense to allow people to edit the fields in the admin.

At best it will be confusing for regular users, I would like to encourage them to use this UI to provide more detail when reporting on one of their scheduled Beat tasks that has failed but don't want them to edit things.

I suppose some people might be using it as a testing tool or reprocessing results they edit the status of somehow though, so this adds a `DJANGO_CELERY_RESULTS` Django setting, with an `ALLOW_EDITS` key that can be set.

So you can add:

```python
DJANGO_CELERY_RESULTS: {
    'ALLOW_EDITS': False
}
```

to your Django config and it will make all fields read-only.

Default behaviour is unchanged.