### PR TITLE
Update database.py to prevent double JSON encoding

### DIFF
--- a/django_celery_results/backends/database.py
+++ b/django_celery_results/backends/database.py
@@ -16,7 +16,7 @@ class DatabaseBackend(BaseDictBackend):
     def _store_result(self, task_id, result, status,
                       traceback=None, request=None):
         """Store return value and status of an executed task."""
-        content_type, content_encoding, result = self.encode_content(result)
+        content_type, content_encoding, _ = self.encode_content(result)
         _, _, meta = self.encode_content({
             'children': self.current_task_children(request),
         })


### PR DESCRIPTION
When you encode a result in _store_result function, the result encoded two times. For example, in my case/project, celery task is returning a class object that is not JSON serializable. In this case, i received an error like; "kombu.exceptions.EncodeError: Object of type Output is not JSON serializable". 

After that, i serialize the object with this line in my task function; "json.dumps(result, default=lambda o: getattr(o, '__dict__', str(o)))". It worked but another problem occurred. The new problem was double serialization. After i serialize the result in task function, the result is encoding to JSON  in _store_result function again via this line: "content_type, content_encoding, result = self.encode_content(result)". 

To prevent double encoding, i recommend to remove JSON encoding from _store_result function. I changed it and it is working well now. Otherwise, the result must decoded two times to get JSON object. "json.loads(json.loads(task.result))".