### PR TITLE
use queryset's deletion method instead

### DIFF
--- a/django_celery_results/managers.py
+++ b/django_celery_results/managers.py
@@ -159,8 +159,4 @@ class TaskResultManager(models.Manager):
         meta = self.model._meta
         with transaction.atomic():
             self.get_all_expired(expires).update(hidden=True)
-            cursor = self.connection_for_write().cursor()
-            cursor.execute(
-                'DELETE FROM {0.db_table} WHERE hidden=%s'.format(meta),
-                (True, ),
-            )
+            self.filter(hidden=True).delete()

--- a/django_celery_results/managers.py
+++ b/django_celery_results/managers.py
@@ -156,7 +156,6 @@ class TaskResultManager(models.Manager):
 
     def delete_expired(self, expires):
         """Delete all expired results."""
-        meta = self.model._meta
         with transaction.atomic():
             self.get_all_expired(expires).update(hidden=True)
             self.filter(hidden=True).delete()


### PR DESCRIPTION
To resolve issue #79 using the delete() method of a queryset.
All unit tests are passed. Please review if there is any side effect.