### PR TITLE
Add support for hiding sensitive information with celery argsrepr and kwargsrepr

### DIFF
--- a/django_celery_results/backends/database.py
+++ b/django_celery_results/backends/database.py
@@ -22,8 +22,10 @@ class DatabaseBackend(BaseDictBackend):
         })
 
         task_name = getattr(request, 'task', None) if request else None
-        task_args = getattr(request, 'args', None) if request else None
-        task_kwargs = getattr(request, 'kwargs', None) if request else None
+        task_args = getattr(request,
+                            'argsrepr', getattr(request, 'args', None))
+        task_kwargs = getattr(request,
+                              'kwargsrepr', getattr(request, 'kwargs', None))
 
         self.TaskModel._default_manager.store_result(
             content_type, content_encoding,

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import mock
 import celery
 import pytest
 
@@ -77,3 +78,19 @@ class test_DatabaseBackend:
             # bug in 3.1.10 means result did not clear cache after forget.
             x._cache = None
         assert x.result is None
+
+    def test_backend_secrets(self):
+        tid = uuid()
+        request = mock.MagicMock()
+        request.task = 'my_task'
+        request.args = ['a', 1, 'password']
+        request.kwargs = {'c': 3, 'd': 'e', 'password': 'password'}
+        request.argsrepr = 'argsrepr'
+        request.kwargsrepr = 'kwargsrepr'
+        result = {'foo': 'baz'}
+
+        self.b.mark_as_done(tid, result, request=request)
+
+        mindb = self.b.get_task_meta(tid)
+        assert mindb.get('task_args') == 'argsrepr'
+        assert mindb.get('task_kwargs') == 'kwargsrepr'


### PR DESCRIPTION
Current version ignores argsrepr and kwargsrepr so sensitive information is saved in the database...this change fixes that:
Refer to
http://docs.celeryproject.org/en/latest/userguide/tasks.html#hiding-sensitive-information-in-arguments
for more information on hiding sensitive information.