### PR TITLE
Fix tox file for Django 2.1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ envlist =
 [travis:env]
 DJANGO =
     1.11: django111
-    2.1: django20
+    2.1: django21
     2.2: django22
 
 [testenv]


### PR DESCRIPTION
It seems Django 2.1 wasn't properly tested on Travis due to a copy paste error.