### PR TITLE
change double quotes to single quotes for support mysql5.6 query

### DIFF
--- a/django_celery_results/managers.py
+++ b/django_celery_results/managers.py
@@ -148,8 +148,8 @@ class TaskResultManager(models.Manager):
             # MariaDB and MySQL since 8.0 have different transaction isolation
             # variables: the former has tx_isolation, while the latter has
             # transaction_isolation
-            if cursor.execute('SHOW VARIABLES WHERE variable_name IN '
-                              '("tx_isolation", "transaction_isolation");'):
+            if cursor.execute("SHOW VARIABLES WHERE variable_name IN "
+                              "('tx_isolation", "transaction_isolation');"):
                 isolation = cursor.fetchone()[1]
                 if isolation == 'REPEATABLE-READ':
                     warnings.warn(TxIsolationWarning(W_ISOLATION_REP.strip()))


### PR DESCRIPTION
The origin query would have the following error when querying mysql5.6.
```
Unknown column 'tx_isolation' in 'where clause'
```
