### PR TITLE
Adding the Tidelift marketing text

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,3 +115,9 @@ max_length of **191** seems to work for MySQL.
 .. |pyimp| image:: https://img.shields.io/pypi/implementation/django-celery-results.svg
     :alt: Support Python implementations.
     :target: http://pypi.python.org/pypi/django-celery-results/
+    
+django-celery-results as part of the Tidelift Subscription
+-----------------
+
+The maintainers of django-celery-results and thousands of other packages are working with Tidelift to deliver commercial support and maintenance for the open source dependencies you use to build your applications. Save time, reduce risk, and improve code health, while paying the maintainers of the exact dependencies you use. [Learn more.](https://tidelift.com/subscription/pkg/pypi-django-celery-results?utm_source=pypi-django-celery-results&utm_medium=referral&utm_campaign=readme&utm_term=repo)
+


### PR DESCRIPTION
@auvipy as requested, here is the README marketing text