### PR TITLE
add task status api from django-celery

### DIFF
--- a/django_celery_results/urls.py
+++ b/django_celery_results/urls.py
@@ -1,0 +1,27 @@
+"""URLs defined for celery.
+
+* ``/$task_id/done/``
+    URL to :func:`~celery.views.is_successful`.
+* ``/$task_id/status/``
+    URL  to :func:`~celery.views.task_status`.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from django.conf.urls import url
+
+from . import views
+
+task_pattern = r'(?P<task_id>[\w\d\-\.]+)'
+
+urlpatterns = [
+    url(
+        r'^%s/done/?$' % task_pattern,
+        views.is_task_successful,
+        name='celery-is_task_successful'
+    ),
+    url(
+        r'^%s/status/?$' % task_pattern,
+        views.task_status,
+        name='celery-task_status'
+    ),
+]

--- a/django_celery_results/views.py
+++ b/django_celery_results/views.py
@@ -1,0 +1,30 @@
+"""Views."""
+from __future__ import absolute_import, unicode_literals
+
+from django.http import JsonResponse
+
+from celery import states
+from celery.result import AsyncResult
+from celery.utils import get_full_cls_name
+from celery.utils.encoding import safe_repr
+
+
+def is_task_successful(request, task_id):
+    """Return task execution status in JSON format."""
+    return JsonResponse({'task': {
+        'id': task_id,
+        'executed': AsyncResult(task_id).successful(),
+    }})
+
+
+def task_status(request, task_id):
+    """Return task status and result in JSON format."""
+    result = AsyncResult(task_id)
+    state, retval = result.state, result.result
+    response_data = {'id': task_id, 'status': state, 'result': retval}
+    if state in states.EXCEPTION_STATES:
+        traceback = result.traceback
+        response_data.update({'result': safe_repr(retval),
+                              'exc': get_full_cls_name(retval.__class__),
+                              'traceback': traceback})
+    return JsonResponse({'task': response_data})

--- a/t/unit/test_views.py
+++ b/t/unit/test_views.py
@@ -1,0 +1,75 @@
+from __future__ import absolute_import, unicode_literals
+
+import json
+import pytest
+
+from django.test import TestCase
+from django.test.client import RequestFactory
+
+from celery import states, uuid
+
+from django_celery_results.models import TaskResult
+from django_celery_results.views import is_task_successful, task_status
+
+
+@pytest.mark.usefixtures('depends_on_current_app')
+class test_Views(TestCase):
+    @pytest.fixture(autouse=True)
+    def setup_app(self, app):
+        self.app = app
+        self.app.conf.result_serializer = 'json'
+        self.app.conf.result_backend = (
+            'django_celery_results.backends:DatabaseBackend'
+        )
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def create_task_result(self):
+        id = uuid()
+        taskmeta, created = TaskResult.objects.get_or_create(task_id=id)
+        return taskmeta
+
+    def test_is_task_successful(self):
+        taskmeta = self.create_task_result()
+        request = self.factory.get('/done/{}'.format(taskmeta.task_id))
+        response = is_task_successful(request, taskmeta.task_id)
+        assert response
+        result = json.loads(response.content.decode('utf-8'))
+        assert result['task']['executed'] is False
+
+        TaskResult.objects.store_result(
+            'application/json',
+            'utf-8',
+            taskmeta.task_id,
+            json.dumps({'result': True}),
+            status=states.SUCCESS
+        )
+
+        request = self.factory.get('/done/{}'.format(taskmeta.task_id))
+        response = is_task_successful(request, taskmeta.task_id)
+        assert response
+        result = json.loads(response.content.decode('utf-8'))
+        assert result['task']['executed'] is True
+
+    def test_task_status(self):
+        taskmeta = self.create_task_result()
+        request = self.factory.get('/status/{}'.format(taskmeta.task_id))
+        response = task_status(request, taskmeta.task_id)
+        assert response
+        result = json.loads(response.content.decode('utf-8'))
+        assert result['task']['status'] is not states.SUCCESS
+
+        TaskResult.objects.store_result(
+            'application/json',
+            'utf-8',
+            taskmeta.task_id,
+            json.dumps({'result': True}),
+            status=states.SUCCESS
+        )
+
+        request = self.factory.get('/status/{}'.format(taskmeta.task_id))
+        response = task_status(request, taskmeta.task_id)
+        assert response
+        result = json.loads(response.content.decode('utf-8'))
+        assert result['task']['status'] == states.SUCCESS


### PR DESCRIPTION
This adds the task status API from `django-celery` into the new module (resolves #103 ). Much of the code is copy-paste from the old library, but some changes were necessary for compatibility with newer versions Celery et al. For that reason it was easier to write new tests than adapt the old ones, but of course if that's not OK I can do it the other way.

In my local environment, all tests pass except for `apicheck`, which fails for me because my environment still defaults to python2.7, but `sphinx-celery` requires a version of `sphinx` that only supports python3.5 or greater. 

If I've missed anything or need to clean anything up I'll be happy to!