### PR TITLE
Make TaskResults read-only by default

### DIFF
--- a/django_celery_results/admin.py
+++ b/django_celery_results/admin.py
@@ -9,7 +9,7 @@ from django.utils.translation import ugettext_lazy as _
 try:
     ALLOW_EDITS = settings.DJANGO_CELERY_RESULTS['ALLOW_EDITS']
 except (AttributeError, KeyError):
-    ALLOW_EDITS = True
+    ALLOW_EDITS = False
     pass
 
 from .models import TaskResult


### PR DESCRIPTION
Django-Celery-Results is meant for monitoring. There is little to no reason to allow editing task results. So it would be better to allow edits only if a user explicitly specifies this setting. This is how it worked in django-celery.

Previous PR: https://github.com/celery/django-celery-results/pull/56