### PR TITLE
Fix bug in warn_if_repeatable_read (introduced in PR #110).

### DIFF
--- a/django_celery_results/managers.py
+++ b/django_celery_results/managers.py
@@ -149,7 +149,7 @@ class TaskResultManager(models.Manager):
             # variables: the former has tx_isolation, while the latter has
             # transaction_isolation
             if cursor.execute("SHOW VARIABLES WHERE variable_name IN "
-                              "('tx_isolation", "transaction_isolation');"):
+                              "('tx_isolation', 'transaction_isolation');"):
                 isolation = cursor.fetchone()[1]
                 if isolation == 'REPEATABLE-READ':
                     warnings.warn(TxIsolationWarning(W_ISOLATION_REP.strip()))


### PR DESCRIPTION
In PR #110 some double quotes were overlooked, resulting in an invalid query.