### PR TITLE
Remove redundant link from README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,9 +25,6 @@ Installing
 The installation instructions for this extension is available
 from the `Celery documentation`_:
 
-http://docs.celeryproject.org/en/latest/django/first-steps-with-django.html#django-celery-results-using-the-django-orm-cache-as-a-result-backend
-
-
 .. _`Celery documentation`:
     http://docs.celeryproject.org/en/latest/django/first-steps-with-django.html#django-celery-results-using-the-django-orm-cache-as-a-result-backend
 

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Installing
 ==========
 
 The installation instructions for this extension is available
-from the `Celery documentation`_:
+from the `Celery documentation`_
 
 .. _`Celery documentation`:
     http://docs.celeryproject.org/en/latest/django/first-steps-with-django.html#django-celery-results-using-the-django-orm-cache-as-a-result-backend


### PR DESCRIPTION
Remove the repeated link that is already hyper linked to `Celery documentation`