### PR TITLE
Change ugettext_lazy to gettext_lazy to remove deprecation Warning

### DIFF
--- a/django_celery_results/admin.py
+++ b/django_celery_results/admin.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, unicode_literals
 from django.contrib import admin
 
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 try:
     ALLOW_EDITS = settings.DJANGO_CELERY_RESULTS['ALLOW_EDITS']

--- a/django_celery_results/apps.py
+++ b/django_celery_results/apps.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 __all__ = ['CeleryResultConfig']
 

--- a/django_celery_results/models.py
+++ b/django_celery_results/models.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 
 from django.conf import settings
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from celery import states
 from celery.five import python_2_unicode_compatible


### PR DESCRIPTION
Change  ugettext_lazy to gettext_lazy to follows Django recommendations:

```
RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
```

