### PR TITLE
Many bug fixes related with DatabaseBackend._store_result function

### DIFF
--- a/django_celery_results/backends/database.py
+++ b/django_celery_results/backends/database.py
@@ -78,9 +78,13 @@ class DatabaseBackend(BaseDictBackend):
         task_args = self.decode_content(obj, res.get('task_args'))
         task_kwargs = self.decode_content(obj, res.get('task_kwargs'))
 
+        # the right names are args/kwargs, not task_args/task_kwargs,
+        # keep both for backward compatibility
         res.update(
             meta, result=result, task_args=task_args,
             task_kwargs=task_kwargs,
+            args=task_args,
+            kwargs=task_kwargs,
         )
         return self.meta_from_decoded(res)
 

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -110,6 +110,27 @@ class test_DatabaseBackend:
         assert ar.args == mindb.get('task_args')
         assert ar.kwargs == mindb.get('task_kwargs')
 
+        # check backward compatibility
+        task_kwargs2 = str(request.kwargs)
+        task_args2 = str(request.args)
+        assert tr.task_args != task_args2
+        assert tr.task_kwargs != task_kwargs2
+        tr.task_args = task_args2
+        tr.task_kwargs = task_kwargs2
+        tr.save()
+        mindb = self.b.get_task_meta(tid2)
+        assert bool(re.match(
+            r"\['a', 1, <.*SomeClass object at .*>\]",
+            mindb.get('task_args')
+        ))
+        assert bool(re.match(
+            r"{'c': 6, 'd': 'e', 'f': <.*SomeClass object at .*>}",
+            mindb.get('task_kwargs')
+        ))
+        ar = AsyncResult(tid2)
+        assert ar.args == mindb.get('task_args')
+        assert ar.kwargs == mindb.get('task_kwargs')
+
         tid3 = uuid()
         try:
             raise KeyError('foo')
@@ -233,6 +254,21 @@ class test_DatabaseBackend:
         assert json.loads(tr.task_kwargs) == "{'c': 6, 'd': 'e', 'f': False}"
 
         # check async_result
+        ar = AsyncResult(tid2)
+        assert ar.args == mindb.get('task_args')
+        assert ar.kwargs == mindb.get('task_kwargs')
+
+        # check backward compatibility
+        task_kwargs2 = str(request.kwargs)
+        task_args2 = str(request.args)
+        assert tr.task_args != task_args2
+        assert tr.task_kwargs != task_kwargs2
+        tr.task_args = task_args2
+        tr.task_kwargs = task_kwargs2
+        tr.save()
+        mindb = self.b.get_task_meta(tid2)
+        assert mindb.get('task_args') == "['a', 1, True]"
+        assert mindb.get('task_kwargs') == "{'c': 6, 'd': 'e', 'f': False}"
         ar = AsyncResult(tid2)
         assert ar.args == mindb.get('task_args')
         assert ar.kwargs == mindb.get('task_kwargs')

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -2,12 +2,16 @@ from __future__ import absolute_import, unicode_literals
 
 import mock
 import celery
+import json
 import pytest
+import re
+import pickle
 
 from celery import uuid
 from celery import states
 from celery.app.task import Context
 from celery.result import GroupResult, AsyncResult
+from celery.utils.serialization import b64decode
 from celery.worker.request import Request
 
 from django_celery_results.backends.database import DatabaseBackend
@@ -72,16 +76,20 @@ class test_DatabaseBackend:
         assert mindb.get('result').get('bar').data == 12345
         assert len(mindb.get('worker')) > 1
         assert mindb.get('task_name') == 'my_task'
+        assert bool(re.match(
+            r"\['a', 1, <.*SomeClass object at .*>\]",
+            mindb.get('task_args')
+        ))
+        assert bool(re.match(
+            r"{'c': 6, 'd': 'e', 'f': <.*SomeClass object at .*>}",
+            mindb.get('task_kwargs')
+        ))
 
-        assert len(mindb.get('task_args')) == 3
-        assert mindb.get('task_args')[0] == 'a'
-        assert mindb.get('task_args')[1] == 1
-        assert mindb.get('task_args')[2].data == 67
-
-        assert len(mindb.get('task_kwargs')) == 3
-        assert mindb.get('task_kwargs')['c'] == 6
-        assert mindb.get('task_kwargs')['d'] == 'e'
-        assert mindb.get('task_kwargs')['f'].data == 89
+        tr = TaskResult.objects.get(task_id=tid2)
+        task_args = pickle.loads(b64decode(tr.task_args))
+        task_kwargs = pickle.loads(b64decode(tr.task_kwargs))
+        assert task_args == mindb.get('task_args')
+        assert task_kwargs == mindb.get('task_kwargs')
 
         tid3 = uuid()
         try:
@@ -112,16 +120,20 @@ class test_DatabaseBackend:
         assert mindb.get('result') == 'foo'
         assert mindb.get('task_name') == 'my_task'
         assert len(mindb.get('worker')) > 1
+        assert bool(re.match(
+            r"\['a', 1, <.*SomeClass object at .*>\]",
+            mindb.get('task_args')
+        ))
+        assert bool(re.match(
+            r"{'c': 6, 'd': 'e', 'f': <.*SomeClass object at .*>}",
+            mindb.get('task_kwargs')
+        ))
 
-        assert len(mindb.get('task_args')) == 3
-        assert mindb.get('task_args')[0] == 'a'
-        assert mindb.get('task_args')[1] == 1
-        assert mindb.get('task_args')[2].data == 67
-
-        assert len(mindb.get('task_kwargs')) == 3
-        assert mindb.get('task_kwargs')['c'] == 6
-        assert mindb.get('task_kwargs')['d'] == 'e'
-        assert mindb.get('task_kwargs')['f'].data == 89
+        tr = TaskResult.objects.get(task_id=tid2)
+        task_args = pickle.loads(b64decode(tr.task_args))
+        task_kwargs = pickle.loads(b64decode(tr.task_kwargs))
+        assert task_args == mindb.get('task_args')
+        assert task_kwargs == mindb.get('task_kwargs')
 
     def test_backend__pickle_serialization__bytes_result(self):
         self.app.conf.result_serializer = 'pickle'
@@ -143,16 +155,82 @@ class test_DatabaseBackend:
         assert mindb.get('result') == b'foo'
         assert mindb.get('task_name') == 'my_task'
         assert len(mindb.get('worker')) > 1
+        assert bool(re.match(
+            r"\['a', 1, <.*SomeClass object at .*>\]",
+            mindb.get('task_args')
+        ))
+        assert bool(re.match(
+            r"{'c': 6, 'd': 'e', 'f': <.*SomeClass object at .*>}",
+            mindb.get('task_kwargs')
+        ))
 
-        assert len(mindb.get('task_args')) == 3
-        assert mindb.get('task_args')[0] == 'a'
-        assert mindb.get('task_args')[1] == 1
-        assert mindb.get('task_args')[2].data == 67
+        tr = TaskResult.objects.get(task_id=tid2)
+        task_args = pickle.loads(b64decode(tr.task_args))
+        task_kwargs = pickle.loads(b64decode(tr.task_kwargs))
+        assert task_args == mindb.get('task_args')
+        assert task_kwargs == mindb.get('task_kwargs')
 
-        assert len(mindb.get('task_kwargs')) == 3
-        assert mindb.get('task_kwargs')['c'] == 6
-        assert mindb.get('task_kwargs')['d'] == 'e'
-        assert mindb.get('task_kwargs')['f'].data == 89
+    def test_backend__json_serialization__dict_result(self):
+        self.app.conf.result_serializer = 'json'
+        self.app.conf.accept_content = {'pickle', 'json'}
+        self.b = DatabaseBackend(app=self.app)
+
+        tid2 = uuid()
+        request = self._create_request(
+            task_id=tid2,
+            name='my_task',
+            args=['a', 1, True],
+            kwargs={'c': 6, 'd': 'e', 'f': False},
+        )
+        result = {'foo': 'baz', 'bar': True}
+
+        self.b.mark_as_done(tid2, result, request=request)
+        mindb = self.b.get_task_meta(tid2)
+
+        assert mindb.get('result').get('foo') == 'baz'
+        assert mindb.get('result').get('bar') is True
+        assert mindb.get('task_name') == 'my_task'
+        assert mindb.get('task_args') == "['a', 1, True]"
+        assert mindb.get('task_kwargs') == "{'c': 6, 'd': 'e', 'f': False}"
+
+        tr = TaskResult.objects.get(task_id=tid2)
+        assert json.loads(tr.task_args) == "['a', 1, True]"
+        assert json.loads(tr.task_kwargs) == "{'c': 6, 'd': 'e', 'f': False}"
+
+        tid3 = uuid()
+        try:
+            raise KeyError('foo')
+        except KeyError as exception:
+            self.b.mark_as_failure(tid3, exception)
+
+        assert self.b.get_status(tid3) == states.FAILURE
+        assert isinstance(self.b.get_result(tid3), KeyError)
+
+    def test_backend__json_serialization__str_result(self):
+        self.app.conf.result_serializer = 'json'
+        self.app.conf.accept_content = {'pickle', 'json'}
+        self.b = DatabaseBackend(app=self.app)
+
+        tid2 = uuid()
+        request = self._create_request(
+            task_id=tid2,
+            name='my_task',
+            args=['a', 1, True],
+            kwargs={'c': 6, 'd': 'e', 'f': False},
+        )
+        result = 'foo'
+
+        self.b.mark_as_done(tid2, result, request=request)
+        mindb = self.b.get_task_meta(tid2)
+
+        assert mindb.get('result') == 'foo'
+        assert mindb.get('task_name') == 'my_task'
+        assert mindb.get('task_args') == "['a', 1, True]"
+        assert mindb.get('task_kwargs') == "{'c': 6, 'd': 'e', 'f': False}"
+
+        tr = TaskResult.objects.get(task_id=tid2)
+        assert json.loads(tr.task_args) == "['a', 1, True]"
+        assert json.loads(tr.task_kwargs) == "{'c': 6, 'd': 'e', 'f': False}"
 
     def xxx_backend(self):
         tid = uuid()
@@ -184,7 +262,11 @@ class test_DatabaseBackend:
             x._cache = None
         assert x.result is None
 
-    def test_backend_secrets(self):
+    def test_secrets__pickle_serialization(self):
+        self.app.conf.result_serializer = 'pickle'
+        self.app.conf.accept_content = {'pickle', 'json'}
+        self.b = DatabaseBackend(app=self.app)
+
         tid = uuid()
         request = self._create_request(
             task_id=tid,
@@ -199,9 +281,43 @@ class test_DatabaseBackend:
         self.b.mark_as_done(tid, result, request=request)
 
         mindb = self.b.get_task_meta(tid)
+        assert mindb.get('result') == {'foo': 'baz'}
         assert mindb.get('task_args') == 'argsrepr'
         assert mindb.get('task_kwargs') == 'kwargsrepr'
         assert len(mindb.get('worker')) > 1
+
+        tr = TaskResult.objects.get(task_id=tid)
+        task_args = pickle.loads(b64decode(tr.task_args))
+        task_kwargs = pickle.loads(b64decode(tr.task_kwargs))
+        assert task_args == 'argsrepr'
+        assert task_kwargs == 'kwargsrepr'
+
+    def test_secrets__json_serialization(self):
+        self.app.conf.result_serializer = 'json'
+        self.app.conf.accept_content = {'pickle', 'json'}
+        self.b = DatabaseBackend(app=self.app)
+
+        tid = uuid()
+        request = self._create_request(
+            task_id=tid,
+            name='my_task',
+            args=['a', 1, True],
+            kwargs={'c': 6, 'd': 'e', 'f': False},
+            argsrepr='argsrepr',
+            kwargsrepr='kwargsrepr',
+        )
+        result = {'foo': 'baz'}
+
+        self.b.mark_as_done(tid, result, request=request)
+
+        mindb = self.b.get_task_meta(tid)
+        assert mindb.get('result') == {'foo': 'baz'}
+        assert mindb.get('task_args') == 'argsrepr'
+        assert mindb.get('task_kwargs') == 'kwargsrepr'
+
+        tr = TaskResult.objects.get(task_id=tid)
+        assert json.loads(tr.task_args) == 'argsrepr'
+        assert json.loads(tr.task_kwargs) == 'kwargsrepr'
 
     def test_on_chord_part_return(self):
         """Test if the ChordCounter is properly decremented and the callback is

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -84,6 +84,7 @@ class test_DatabaseBackend:
         self.b.mark_as_done(tid2, result, request=request)
         mindb = self.b.get_task_meta(tid2)
 
+        # check task meta
         assert mindb.get('result').get('foo') == 'baz'
         assert mindb.get('result').get('bar').data == 12345
         assert len(mindb.get('worker')) > 1
@@ -97,11 +98,17 @@ class test_DatabaseBackend:
             mindb.get('task_kwargs')
         ))
 
+        # check task_result object
         tr = TaskResult.objects.get(task_id=tid2)
         task_args = pickle.loads(b64decode(tr.task_args))
         task_kwargs = pickle.loads(b64decode(tr.task_kwargs))
         assert task_args == mindb.get('task_args')
         assert task_kwargs == mindb.get('task_kwargs')
+
+        # check async_result
+        ar = AsyncResult(tid2)
+        assert ar.args == mindb.get('task_args')
+        assert ar.kwargs == mindb.get('task_kwargs')
 
         tid3 = uuid()
         try:
@@ -129,6 +136,7 @@ class test_DatabaseBackend:
         self.b.mark_as_done(tid2, result, request=request)
         mindb = self.b.get_task_meta(tid2)
 
+        # check task meta
         assert mindb.get('result') == 'foo'
         assert mindb.get('task_name') == 'my_task'
         assert len(mindb.get('worker')) > 1
@@ -141,11 +149,17 @@ class test_DatabaseBackend:
             mindb.get('task_kwargs')
         ))
 
+        # check task_result object
         tr = TaskResult.objects.get(task_id=tid2)
         task_args = pickle.loads(b64decode(tr.task_args))
         task_kwargs = pickle.loads(b64decode(tr.task_kwargs))
         assert task_args == mindb.get('task_args')
         assert task_kwargs == mindb.get('task_kwargs')
+
+        # check async_result
+        ar = AsyncResult(tid2)
+        assert ar.args == mindb.get('task_args')
+        assert ar.kwargs == mindb.get('task_kwargs')
 
     def test_backend__pickle_serialization__bytes_result(self):
         self.app.conf.result_serializer = 'pickle'
@@ -164,6 +178,7 @@ class test_DatabaseBackend:
         self.b.mark_as_done(tid2, result, request=request)
         mindb = self.b.get_task_meta(tid2)
 
+        # check task meta
         assert mindb.get('result') == b'foo'
         assert mindb.get('task_name') == 'my_task'
         assert len(mindb.get('worker')) > 1
@@ -176,11 +191,17 @@ class test_DatabaseBackend:
             mindb.get('task_kwargs')
         ))
 
+        # check task_result objects
         tr = TaskResult.objects.get(task_id=tid2)
         task_args = pickle.loads(b64decode(tr.task_args))
         task_kwargs = pickle.loads(b64decode(tr.task_kwargs))
         assert task_args == mindb.get('task_args')
         assert task_kwargs == mindb.get('task_kwargs')
+
+        # check async_result
+        ar = AsyncResult(tid2)
+        assert ar.args == mindb.get('task_args')
+        assert ar.kwargs == mindb.get('task_kwargs')
 
     def test_backend__json_serialization__dict_result(self):
         self.app.conf.result_serializer = 'json'
@@ -199,15 +220,22 @@ class test_DatabaseBackend:
         self.b.mark_as_done(tid2, result, request=request)
         mindb = self.b.get_task_meta(tid2)
 
+        # check task meta
         assert mindb.get('result').get('foo') == 'baz'
         assert mindb.get('result').get('bar') is True
         assert mindb.get('task_name') == 'my_task'
         assert mindb.get('task_args') == "['a', 1, True]"
         assert mindb.get('task_kwargs') == "{'c': 6, 'd': 'e', 'f': False}"
 
+        # check task_result object
         tr = TaskResult.objects.get(task_id=tid2)
         assert json.loads(tr.task_args) == "['a', 1, True]"
         assert json.loads(tr.task_kwargs) == "{'c': 6, 'd': 'e', 'f': False}"
+
+        # check async_result
+        ar = AsyncResult(tid2)
+        assert ar.args == mindb.get('task_args')
+        assert ar.kwargs == mindb.get('task_kwargs')
 
         tid3 = uuid()
         try:
@@ -235,14 +263,21 @@ class test_DatabaseBackend:
         self.b.mark_as_done(tid2, result, request=request)
         mindb = self.b.get_task_meta(tid2)
 
+        # check task meta
         assert mindb.get('result') == 'foo'
         assert mindb.get('task_name') == 'my_task'
         assert mindb.get('task_args') == "['a', 1, True]"
         assert mindb.get('task_kwargs') == "{'c': 6, 'd': 'e', 'f': False}"
 
+        # check task_result object
         tr = TaskResult.objects.get(task_id=tid2)
         assert json.loads(tr.task_args) == "['a', 1, True]"
         assert json.loads(tr.task_kwargs) == "{'c': 6, 'd': 'e', 'f': False}"
+
+        # check async_result
+        ar = AsyncResult(tid2)
+        assert ar.args == mindb.get('task_args')
+        assert ar.kwargs == mindb.get('task_kwargs')
 
     def test_backend__pickle_serialization__dict_result__protocol_1(self):
         self.app.conf.result_serializer = 'pickle'
@@ -262,6 +297,7 @@ class test_DatabaseBackend:
         self.b.mark_as_done(tid2, result, request=request)
         mindb = self.b.get_task_meta(tid2)
 
+        # check task meta
         assert mindb.get('result').get('foo') == 'baz'
         assert mindb.get('result').get('bar').data == 12345
         assert mindb.get('task_name') == 'my_task'
@@ -274,6 +310,7 @@ class test_DatabaseBackend:
         assert mindb.get('task_kwargs')['d'] == 'e'
         assert mindb.get('task_kwargs')['f'].data == 89
 
+        # check task_result object
         tr = TaskResult.objects.get(task_id=tid2)
         task_args = pickle.loads(b64decode(tr.task_args))
         assert task_args[0] == 'a'
@@ -312,6 +349,7 @@ class test_DatabaseBackend:
         self.b.mark_as_done(tid2, result, request=request)
         mindb = self.b.get_task_meta(tid2)
 
+        # check task meta
         assert mindb.get('result') == 'foo'
         assert mindb.get('task_name') == 'my_task'
 
@@ -323,6 +361,7 @@ class test_DatabaseBackend:
         assert mindb.get('task_kwargs')['d'] == 'e'
         assert mindb.get('task_kwargs')['f'].data == 89
 
+        # check task_result object
         tr = TaskResult.objects.get(task_id=tid2)
         task_args = pickle.loads(b64decode(tr.task_args))
         assert task_args[0] == 'a'
@@ -352,6 +391,7 @@ class test_DatabaseBackend:
         self.b.mark_as_done(tid2, result, request=request)
         mindb = self.b.get_task_meta(tid2)
 
+        # check task meta
         assert mindb.get('result') == b'foo'
         assert mindb.get('task_name') == 'my_task'
 
@@ -363,6 +403,7 @@ class test_DatabaseBackend:
         assert mindb.get('task_kwargs')['d'] == 'e'
         assert mindb.get('task_kwargs')['f'].data == 89
 
+        # check task_result object
         tr = TaskResult.objects.get(task_id=tid2)
         task_args = pickle.loads(b64decode(tr.task_args))
         assert task_args[0] == 'a'
@@ -392,12 +433,14 @@ class test_DatabaseBackend:
         self.b.mark_as_done(tid2, result, request=request)
         mindb = self.b.get_task_meta(tid2)
 
+        # check task meta
         assert mindb.get('result').get('foo') == 'baz'
         assert mindb.get('result').get('bar') is True
         assert mindb.get('task_name') == 'my_task'
         assert mindb.get('task_args') == ['a', 1, True]
         assert mindb.get('task_kwargs') == {'c': 6, 'd': 'e', 'f': False}
 
+        # check task_result object
         tr = TaskResult.objects.get(task_id=tid2)
         assert json.loads(tr.task_args) == ['a', 1, True]
         assert json.loads(tr.task_kwargs) == {'c': 6, 'd': 'e', 'f': False}
@@ -429,11 +472,13 @@ class test_DatabaseBackend:
         self.b.mark_as_done(tid2, result, request=request)
         mindb = self.b.get_task_meta(tid2)
 
+        # check task meta
         assert mindb.get('result') == 'foo'
         assert mindb.get('task_name') == 'my_task'
         assert mindb.get('task_args') == ['a', 1, True]
         assert mindb.get('task_kwargs') == {'c': 6, 'd': 'e', 'f': False}
 
+        # check task_result object
         tr = TaskResult.objects.get(task_id=tid2)
         assert json.loads(tr.task_args) == ['a', 1, True]
         assert json.loads(tr.task_kwargs) == {'c': 6, 'd': 'e', 'f': False}
@@ -485,18 +530,25 @@ class test_DatabaseBackend:
         result = {'foo': 'baz'}
 
         self.b.mark_as_done(tid, result, request=request)
-
         mindb = self.b.get_task_meta(tid)
+
+        # check task meta
         assert mindb.get('result') == {'foo': 'baz'}
         assert mindb.get('task_args') == 'argsrepr'
         assert mindb.get('task_kwargs') == 'kwargsrepr'
         assert len(mindb.get('worker')) > 1
 
+        # check task_result object
         tr = TaskResult.objects.get(task_id=tid)
         task_args = pickle.loads(b64decode(tr.task_args))
         task_kwargs = pickle.loads(b64decode(tr.task_kwargs))
         assert task_args == 'argsrepr'
         assert task_kwargs == 'kwargsrepr'
+
+        # check async_result
+        ar = AsyncResult(tid)
+        assert ar.args == mindb.get('task_args')
+        assert ar.kwargs == mindb.get('task_kwargs')
 
     def test_secrets__json_serialization(self):
         self.app.conf.result_serializer = 'json'
@@ -515,15 +567,22 @@ class test_DatabaseBackend:
         result = {'foo': 'baz'}
 
         self.b.mark_as_done(tid, result, request=request)
-
         mindb = self.b.get_task_meta(tid)
+
+        # check task meta
         assert mindb.get('result') == {'foo': 'baz'}
         assert mindb.get('task_args') == 'argsrepr'
         assert mindb.get('task_kwargs') == 'kwargsrepr'
 
+        # check task_result object
         tr = TaskResult.objects.get(task_id=tid)
         assert json.loads(tr.task_args) == 'argsrepr'
         assert json.loads(tr.task_kwargs) == 'kwargsrepr'
+
+        # check async_result
+        ar = AsyncResult(tid)
+        assert ar.args == mindb.get('task_args')
+        assert ar.kwargs == mindb.get('task_kwargs')
 
     def test_secrets__pickle_serialization__protocol_1(self):
         self.app.conf.result_serializer = 'pickle'

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -13,6 +13,7 @@ from celery.app.task import Context
 from celery.result import GroupResult, AsyncResult
 from celery.utils.serialization import b64decode
 from celery.worker.request import Request
+from celery.worker.strategy import hybrid_to_proto2
 
 from django_celery_results.backends.database import DatabaseBackend
 from django_celery_results.models import ChordCounter, TaskResult
@@ -36,8 +37,8 @@ class test_DatabaseBackend:
         self.b = DatabaseBackend(app=self.app)
 
     def _create_request(self, task_id, name, args, kwargs,
-                        argsrepr=None, kwargsrepr=None):
-        msg = self.app.amqp.create_task_message(
+                        argsrepr=None, kwargsrepr=None, task_protocol=2):
+        msg = self.app.amqp.task_protocols[task_protocol](
             task_id=task_id,
             name=name,
             args=args,
@@ -45,7 +46,12 @@ class test_DatabaseBackend:
             argsrepr=argsrepr,
             kwargsrepr=kwargsrepr,
         )
-        headers, properties, body, sent_event = msg
+        if task_protocol == 1:
+            body, headers, _, _ = hybrid_to_proto2(msg, msg.body)
+            properties = {}
+            sent_event = {}
+        else:
+            headers, properties, body, sent_event = msg
         context = Context(
             headers=headers,
             properties=properties,
@@ -53,6 +59,12 @@ class test_DatabaseBackend:
             sent_event=sent_event,
         )
         request = Request(context, decoded=True, task=name)
+        if task_protocol == 1:
+            assert request.argsrepr is None
+            assert request.kwargsrepr is None
+        else:
+            assert request.argsrepr is not None
+            assert request.kwargsrepr is not None
         return request
 
     def test_backend__pickle_serialization__dict_result(self):
@@ -232,6 +244,200 @@ class test_DatabaseBackend:
         assert json.loads(tr.task_args) == "['a', 1, True]"
         assert json.loads(tr.task_kwargs) == "{'c': 6, 'd': 'e', 'f': False}"
 
+    def test_backend__pickle_serialization__dict_result__protocol_1(self):
+        self.app.conf.result_serializer = 'pickle'
+        self.app.conf.accept_content = {'pickle', 'json'}
+        self.b = DatabaseBackend(app=self.app)
+
+        tid2 = uuid()
+        request = self._create_request(
+            task_id=tid2,
+            name='my_task',
+            args=['a', 1, SomeClass(67)],
+            kwargs={'c': 6, 'd': 'e', 'f': SomeClass(89)},
+            task_protocol=1,
+        )
+        result = {'foo': 'baz', 'bar': SomeClass(12345)}
+
+        self.b.mark_as_done(tid2, result, request=request)
+        mindb = self.b.get_task_meta(tid2)
+
+        assert mindb.get('result').get('foo') == 'baz'
+        assert mindb.get('result').get('bar').data == 12345
+        assert mindb.get('task_name') == 'my_task'
+
+        assert mindb.get('task_args')[0] == 'a'
+        assert mindb.get('task_args')[1] == 1
+        assert mindb.get('task_args')[2].data == 67
+
+        assert mindb.get('task_kwargs')['c'] == 6
+        assert mindb.get('task_kwargs')['d'] == 'e'
+        assert mindb.get('task_kwargs')['f'].data == 89
+
+        tr = TaskResult.objects.get(task_id=tid2)
+        task_args = pickle.loads(b64decode(tr.task_args))
+        assert task_args[0] == 'a'
+        assert task_args[1] == 1
+        assert task_args[2].data == 67
+
+        task_kwargs = pickle.loads(b64decode(tr.task_kwargs))
+        assert task_kwargs['c'] == 6
+        assert task_kwargs['d'] == 'e'
+        assert task_kwargs['f'].data == 89
+
+        tid3 = uuid()
+        try:
+            raise KeyError('foo')
+        except KeyError as exception:
+            self.b.mark_as_failure(tid3, exception)
+
+        assert self.b.get_status(tid3) == states.FAILURE
+        assert isinstance(self.b.get_result(tid3), KeyError)
+
+    def test_backend__pickle_serialization__str_result__protocol_1(self):
+        self.app.conf.result_serializer = 'pickle'
+        self.app.conf.accept_content = {'pickle', 'json'}
+        self.b = DatabaseBackend(app=self.app)
+
+        tid2 = uuid()
+        request = self._create_request(
+            task_id=tid2,
+            name='my_task',
+            args=['a', 1, SomeClass(67)],
+            kwargs={'c': 6, 'd': 'e', 'f': SomeClass(89)},
+            task_protocol=1,
+        )
+        result = 'foo'
+
+        self.b.mark_as_done(tid2, result, request=request)
+        mindb = self.b.get_task_meta(tid2)
+
+        assert mindb.get('result') == 'foo'
+        assert mindb.get('task_name') == 'my_task'
+
+        assert mindb.get('task_args')[0] == 'a'
+        assert mindb.get('task_args')[1] == 1
+        assert mindb.get('task_args')[2].data == 67
+
+        assert mindb.get('task_kwargs')['c'] == 6
+        assert mindb.get('task_kwargs')['d'] == 'e'
+        assert mindb.get('task_kwargs')['f'].data == 89
+
+        tr = TaskResult.objects.get(task_id=tid2)
+        task_args = pickle.loads(b64decode(tr.task_args))
+        assert task_args[0] == 'a'
+        assert task_args[1] == 1
+        assert task_args[2].data == 67
+
+        task_kwargs = pickle.loads(b64decode(tr.task_kwargs))
+        assert task_kwargs['c'] == 6
+        assert task_kwargs['d'] == 'e'
+        assert task_kwargs['f'].data == 89
+
+    def test_backend__pickle_serialization__bytes_result__protocol_1(self):
+        self.app.conf.result_serializer = 'pickle'
+        self.app.conf.accept_content = {'pickle', 'json'}
+        self.b = DatabaseBackend(app=self.app)
+
+        tid2 = uuid()
+        request = self._create_request(
+            task_id=tid2,
+            name='my_task',
+            args=['a', 1, SomeClass(67)],
+            kwargs={'c': 6, 'd': 'e', 'f': SomeClass(89)},
+            task_protocol=1,
+        )
+        result = b'foo'
+
+        self.b.mark_as_done(tid2, result, request=request)
+        mindb = self.b.get_task_meta(tid2)
+
+        assert mindb.get('result') == b'foo'
+        assert mindb.get('task_name') == 'my_task'
+
+        assert mindb.get('task_args')[0] == 'a'
+        assert mindb.get('task_args')[1] == 1
+        assert mindb.get('task_args')[2].data == 67
+
+        assert mindb.get('task_kwargs')['c'] == 6
+        assert mindb.get('task_kwargs')['d'] == 'e'
+        assert mindb.get('task_kwargs')['f'].data == 89
+
+        tr = TaskResult.objects.get(task_id=tid2)
+        task_args = pickle.loads(b64decode(tr.task_args))
+        assert task_args[0] == 'a'
+        assert task_args[1] == 1
+        assert task_args[2].data == 67
+
+        task_kwargs = pickle.loads(b64decode(tr.task_kwargs))
+        assert task_kwargs['c'] == 6
+        assert task_kwargs['d'] == 'e'
+        assert task_kwargs['f'].data == 89
+
+    def test_backend__json_serialization__dict_result__protocol_1(self):
+        self.app.conf.result_serializer = 'json'
+        self.app.conf.accept_content = {'pickle', 'json'}
+        self.b = DatabaseBackend(app=self.app)
+
+        tid2 = uuid()
+        request = self._create_request(
+            task_id=tid2,
+            name='my_task',
+            args=['a', 1, True],
+            kwargs={'c': 6, 'd': 'e', 'f': False},
+            task_protocol=1,
+        )
+        result = {'foo': 'baz', 'bar': True}
+
+        self.b.mark_as_done(tid2, result, request=request)
+        mindb = self.b.get_task_meta(tid2)
+
+        assert mindb.get('result').get('foo') == 'baz'
+        assert mindb.get('result').get('bar') is True
+        assert mindb.get('task_name') == 'my_task'
+        assert mindb.get('task_args') == ['a', 1, True]
+        assert mindb.get('task_kwargs') == {'c': 6, 'd': 'e', 'f': False}
+
+        tr = TaskResult.objects.get(task_id=tid2)
+        assert json.loads(tr.task_args) == ['a', 1, True]
+        assert json.loads(tr.task_kwargs) == {'c': 6, 'd': 'e', 'f': False}
+
+        tid3 = uuid()
+        try:
+            raise KeyError('foo')
+        except KeyError as exception:
+            self.b.mark_as_failure(tid3, exception)
+
+        assert self.b.get_status(tid3) == states.FAILURE
+        assert isinstance(self.b.get_result(tid3), KeyError)
+
+    def test_backend__json_serialization__str_result__protocol_1(self):
+        self.app.conf.result_serializer = 'json'
+        self.app.conf.accept_content = {'pickle', 'json'}
+        self.b = DatabaseBackend(app=self.app)
+
+        tid2 = uuid()
+        request = self._create_request(
+            task_id=tid2,
+            name='my_task',
+            args=['a', 1, True],
+            kwargs={'c': 6, 'd': 'e', 'f': False},
+            task_protocol=1,
+        )
+        result = 'foo'
+
+        self.b.mark_as_done(tid2, result, request=request)
+        mindb = self.b.get_task_meta(tid2)
+
+        assert mindb.get('result') == 'foo'
+        assert mindb.get('task_name') == 'my_task'
+        assert mindb.get('task_args') == ['a', 1, True]
+        assert mindb.get('task_kwargs') == {'c': 6, 'd': 'e', 'f': False}
+
+        tr = TaskResult.objects.get(task_id=tid2)
+        assert json.loads(tr.task_args) == ['a', 1, True]
+        assert json.loads(tr.task_kwargs) == {'c': 6, 'd': 'e', 'f': False}
+
     def xxx_backend(self):
         tid = uuid()
 
@@ -318,6 +524,77 @@ class test_DatabaseBackend:
         tr = TaskResult.objects.get(task_id=tid)
         assert json.loads(tr.task_args) == 'argsrepr'
         assert json.loads(tr.task_kwargs) == 'kwargsrepr'
+
+    def test_secrets__pickle_serialization__protocol_1(self):
+        self.app.conf.result_serializer = 'pickle'
+        self.app.conf.accept_content = {'pickle', 'json'}
+        self.b = DatabaseBackend(app=self.app)
+
+        tid = uuid()
+        request = self._create_request(
+            task_id=tid,
+            name='my_task',
+            args=['a', 1, SomeClass(67)],
+            kwargs={'c': 6, 'd': 'e', 'f': SomeClass(89)},
+            argsrepr='argsrepr',
+            kwargsrepr='kwargsrepr',
+            task_protocol=1,
+        )
+        result = {'foo': 'baz'}
+
+        self.b.mark_as_done(tid, result, request=request)
+
+        mindb = self.b.get_task_meta(tid)
+        assert mindb.get('result') == {'foo': 'baz'}
+
+        assert mindb.get('task_args')[0] == 'a'
+        assert mindb.get('task_args')[1] == 1
+        assert mindb.get('task_args')[2].data == 67
+
+        assert mindb.get('task_kwargs')['c'] == 6
+        assert mindb.get('task_kwargs')['d'] == 'e'
+        assert mindb.get('task_kwargs')['f'].data == 89
+
+        tr = TaskResult.objects.get(task_id=tid)
+        task_args = pickle.loads(b64decode(tr.task_args))
+        assert task_args[0] == 'a'
+        assert task_args[1] == 1
+        assert task_args[2].data == 67
+
+        task_kwargs = pickle.loads(b64decode(tr.task_kwargs))
+        assert task_kwargs['c'] == 6
+        assert task_kwargs['d'] == 'e'
+        assert task_kwargs['f'].data == 89
+
+    def test_secrets__json_serialization__protocol_1(self):
+        self.app.conf.result_serializer = 'json'
+        self.app.conf.accept_content = {'pickle', 'json'}
+        self.b = DatabaseBackend(app=self.app)
+
+        tid = uuid()
+        request = self._create_request(
+            task_id=tid,
+            name='my_task',
+            args=['a', 1, True],
+            kwargs={'c': 6, 'd': 'e', 'f': False},
+            argsrepr='argsrepr',
+            kwargsrepr='kwargsrepr',
+            task_protocol=1,
+        )
+        result = {'foo': 'baz'}
+
+        self.b.mark_as_done(tid, result, request=request)
+
+        mindb = self.b.get_task_meta(tid)
+
+        assert mindb.get('result') == {'foo': 'baz'}
+        assert mindb.get('task_name') == 'my_task'
+        assert mindb.get('task_args') == ['a', 1, True]
+        assert mindb.get('task_kwargs') == {'c': 6, 'd': 'e', 'f': False}
+
+        tr = TaskResult.objects.get(task_id=tid)
+        assert json.loads(tr.task_args) == ['a', 1, True]
+        assert json.loads(tr.task_kwargs) == {'c': 6, 'd': 'e', 'f': False}
 
     def test_on_chord_part_return(self):
         """Test if the ChordCounter is properly decremented and the callback is


### PR DESCRIPTION
There is no new feature or behaviour change, just regression and bug fixes, and a lot more testing.

5 commits:

1) First of all I've added a commit so the tests use real task requests instead of MagicMocks, so they are more reliable.

2) Encode original input arguments is not possible in task_protocol=2 (as we already discussed in #113 ), but we didn't realize it because of the use of MagicMock. With the changes of the first commit, tests related with encoding input arguments started to fail (as expected). I've fixed these tests.

3) PR #91 made that `None` was stored to `task_args` and `task_kwargs` instead of the actual input arguments if `task_protocol=1`. I've fixed it, so input arguments are now stored in json format (as expected since #78 ).

4) `AsyncResult` class has `args` and `kwargs` [properties](https://github.com/celery/celery/blob/ddb5db72762e00a091a7c4eaef4c07470515f1e1/celery/result.py#L494) which get `args` and `kwargs` keys from task meta.
```python3
    @property
    def args(self):
        return self._get_task_meta().get('args')

    @property
    def kwargs(self):
        return self._get_task_meta().get('kwargs')
```
But in `DatabaseBackend._get_task_meta_for` these values are named `task_args` and `task_kwargs` so the output of the `AsyncResult` propiertes is always `None`.
For backward compatibility, I've added `args` and `kwargs` keys, without removing `task_args` and `task_kwargs`.

5) Fix #176 (backward compatibility)
