### PR TITLE
Add task_args and task_kwargs to searchable fields

### DIFF
--- a/django_celery_results/admin.py
+++ b/django_celery_results/admin.py
@@ -23,7 +23,8 @@ class TaskResultAdmin(admin.ModelAdmin):
     list_display = ('task_id', 'task_name', 'date_done', 'status', 'worker')
     list_filter = ('status', 'date_done', 'task_name', 'worker')
     readonly_fields = ('date_created', 'date_done', 'result', 'meta')
-    search_fields = ('task_name', 'task_id', 'status', 'task_args', 'task_kwargs')
+    search_fields = ('task_name', 'task_id', 'status', 'task_args',
+                     'task_kwargs')
     fieldsets = (
         (None, {
             'fields': (

--- a/django_celery_results/admin.py
+++ b/django_celery_results/admin.py
@@ -23,7 +23,7 @@ class TaskResultAdmin(admin.ModelAdmin):
     list_display = ('task_id', 'task_name', 'date_done', 'status', 'worker')
     list_filter = ('status', 'date_done', 'task_name', 'worker')
     readonly_fields = ('date_created', 'date_done', 'result', 'meta')
-    search_fields = ('task_name', 'task_id', 'status')
+    search_fields = ('task_name', 'task_id', 'status', 'task_args', 'task_kwargs')
     fieldsets = (
         (None, {
             'fields': (


### PR DESCRIPTION
Adding `task_args` and `task_kwargs` to searchable fields in the admin. This is particularly useful in case the arguments provided are specific ids of objects or unique fields.