### PR TITLE
Don't raise an error when ChordCounter is not found

### DIFF
--- a/django_celery_results/backends/database.py
+++ b/django_celery_results/backends/database.py
@@ -137,8 +137,11 @@ class DatabaseBackend(BaseDictBackend):
             # SELECT FOR UPDATE is not supported on all databases
             chord_counter = (
                 ChordCounter.objects.select_for_update()
-                .get(group_id=gid)
+                .filter(group_id=gid).first()
             )
+            if chord_counter is None:
+                logger.warning("Can't find ChordCounter for Group %s", gid)
+                return
             chord_counter.count -= 1
             if chord_counter.count != 0:
                 chord_counter.save()

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -725,6 +725,17 @@ class test_DatabaseBackend:
 
         request.chord.delay.assert_called_once()
 
+    def test_on_chord_part_return_counter_not_found(self):
+        """Test if the chord does not raise an error if the ChordCounter is not found
+
+        Basically this covers the case where a chord was created with a version
+        <2.0.0 and the update was done before the chord was finished
+        """
+        request = mock.MagicMock()
+        request.id = uuid()
+        request.group = uuid()
+        self.b.on_chord_part_return(request=request, state=None, result=None)
+
     def test_callback_failure(self):
         """Test if a failure in the chord callback is properly handled"""
         gid = uuid()


### PR DESCRIPTION
When upgrading from <2.0.0 while current chords are not finished, the ChordCounter object does not exist, breaking the chord.
The `celery.chord_unlock` Task created by the legacy chord should unlock any existing chord while new chord will create the proper ChordCounter object

closes #177 