### PR TITLE
Use the provided chord_size when available

### DIFF
--- a/django_celery_results/backends/database.py
+++ b/django_celery_results/backends/database.py
@@ -119,9 +119,10 @@ class DatabaseBackend(BaseDictBackend):
     def apply_chord(self, header_result, body, **kwargs):
         """Add a ChordCounter with the expected number of results"""
         results = [r.as_tuple() for r in header_result]
+        chord_size = body.get("chord_size", None) or len(results)
         data = json.dumps(results)
         ChordCounter.objects.create(
-            group_id=header_result.id, sub_tasks=data, count=len(results)
+            group_id=header_result.id, sub_tasks=data, count=chord_size
         )
 
     def on_chord_part_return(self, request, state, result, **kwargs):


### PR DESCRIPTION
This will get the Signature["chord_size"] with a fall back to the length of the header when chord_size is not available.
This should correct the chord_size for nested groups in chords

closes #194