### PR TITLE
Remove duplicate indexes

### DIFF
--- a/django_celery_results/migrations/0009_groupresult.py
+++ b/django_celery_results/migrations/0009_groupresult.py
@@ -3,6 +3,21 @@ from django.conf import settings
 from django.db import migrations, models
 
 
+class FakeAddIndex(migrations.AddIndex):
+    """Fake AddIndex to correct for duplicate index
+    added in the original 0009 migration
+    """
+    def database_forwards(self, *args, **kwargs):
+        """Don't do anything"""
+
+    def database_backwards(self, *args, **kwargs):
+        """Also don't do anything on reverting this migration
+
+        The duplicate index will be cleaned up when migrating from the
+        original 0009 to the cleanup 0010
+        """
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -140,13 +155,13 @@ class Migration(migrations.Migration):
                 null=True,
                 verbose_name='Worker'),
         ),
-        migrations.AddIndex(
+        FakeAddIndex(
             model_name='chordcounter',
             index=models.Index(
                 fields=['group_id'],
                 name='django_cele_group_i_299b0d_idx'),
         ),
-        migrations.AddIndex(
+        FakeAddIndex(
             model_name='taskresult',
             index=models.Index(
                 fields=['task_id'],
@@ -182,7 +197,7 @@ class Migration(migrations.Migration):
                 fields=['date_done'],
                 name='django_cele_date_do_f59aad_idx'),
         ),
-        migrations.AddIndex(
+        FakeAddIndex(
             model_name='groupresult',
             index=models.Index(
                 fields=['group_id'],

--- a/django_celery_results/migrations/0010_remove_duplicate_indices.py
+++ b/django_celery_results/migrations/0010_remove_duplicate_indices.py
@@ -1,0 +1,49 @@
+"""
+Migration to amend the 0009 migration released on django_celery_results 2.1.0
+
+That migration introduced duplicate indexes breaking Oracle support.
+This migration will remove those indexes (on non-Oracle db's)
+while in-place changing migration 0009
+to not add the duplicates for new installs
+"""
+
+from django.db import migrations, DatabaseError
+
+
+class TryRemoveIndex(migrations.RemoveIndex):
+    """Operation to remove the Index
+    without reintroducing it on reverting the migration
+    """
+
+    def database_forwards(self, *args, **kwargs):
+        """Remove the index on the database if it exists"""
+        try:
+            super().database_forwards(*args, **kwargs)
+        except DatabaseError:
+            pass
+
+    def database_backwards(self, *args, **kwargs):
+        """Don't re-add the index when reverting this migration"""
+        pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('django_celery_results', '0009_groupresult'),
+    ]
+
+    operations = [
+        TryRemoveIndex(
+            model_name='chordcounter',
+            name='django_cele_group_i_299b0d_idx',
+        ),
+        TryRemoveIndex(
+            model_name='groupresult',
+            name='django_cele_group_i_3cddec_idx',
+        ),
+        TryRemoveIndex(
+            model_name='taskresult',
+            name='django_cele_task_id_7f8fca_idx',
+        ),
+    ]

--- a/django_celery_results/models.py
+++ b/django_celery_results/models.py
@@ -93,7 +93,6 @@ class TaskResult(models.Model):
         verbose_name_plural = _('task results')
 
         indexes = [
-            models.Index(fields=['task_id']),
             models.Index(fields=['task_name']),
             models.Index(fields=['status']),
             models.Index(fields=['worker']),
@@ -143,13 +142,6 @@ class ChordCounter(models.Model):
             "finished"
         )
     )
-
-    class Meta:
-        """Table information."""
-
-        indexes = [
-            models.Index(fields=['group_id']),
-        ]
 
     def group_result(self, app=None):
         """Return the GroupResult of self.
@@ -227,7 +219,6 @@ class GroupResult(models.Model):
         verbose_name_plural = _('group results')
 
         indexes = [
-            models.Index(fields=['group_id']),
             models.Index(fields=['date_created']),
             models.Index(fields=['date_done']),
         ]


### PR DESCRIPTION
### Description
There were explicit indexes added while also defining `unique=True` for the `task_id` and `group_id` fields on all models

This caused two indexes to be created by Django, one for the unique index and one for the explicit index.

Oracle rejects the migration due to duplicated indexes on the same column while Postgres is happy to accept inefficient indexing.

closes #208