### PR TITLE
feat: raw delete expired instead of `Queryset.delete`

### DIFF
--- a/django_celery_results/managers.py
+++ b/django_celery_results/managers.py
@@ -8,7 +8,7 @@ from celery.utils.time import maybe_timedelta
 from django.conf import settings
 from django.db import connections, models, router, transaction
 
-from .utils import now
+from .utils import now, raw_delete
 
 W_ISOLATION_REP = """
 Polling results with transaction isolation level 'repeatable-read'
@@ -88,7 +88,7 @@ class ResultManager(models.Manager):
     def delete_expired(self, expires):
         """Delete all expired results."""
         with transaction.atomic():
-            self.get_all_expired(expires).delete()
+            raw_delete(queryset=self.get_all_expired(expires))
 
 
 class TaskResultManager(ResultManager):

--- a/django_celery_results/utils.py
+++ b/django_celery_results/utils.py
@@ -15,3 +15,11 @@ def now():
         return now_localtime(timezone.now())
     else:
         return timezone.now()
+
+
+def raw_delete(queryset):
+    """
+    Raw delete given queryset. This is to avoid loading objects in-memory (in certain conditions
+    like - singals or cascade check) while deleting large number of rows.
+    """
+    return queryset._raw_delete(queryset.db)


### PR DESCRIPTION
This is avoid unncessary loading of objects in-memory in certain conditions

Closes #232 