### PR TITLE
Fix issue `pydoc.ErrorDuringImport: problem in django_celery_results.…

### DIFF
--- a/django_celery_results/urls.py
+++ b/django_celery_results/urls.py
@@ -49,7 +49,7 @@ urlpatterns = [
         name='celery-is_group_successful'
     ),
     path(
-        'group/status/<task_pattern:group_id> /',
+        'group/status/<task_pattern:group_id>/',
         views.group_status,
         name='celery-group_status'
     ),


### PR DESCRIPTION
…urls - ImproperlyConfigured: URL route 'group/status/<task_pattern:group_id> /' cannot contain whitespace`.