### PR TITLE
Fix properties default value

### DIFF
--- a/django_celery_results/backends/database.py
+++ b/django_celery_results/backends/database.py
@@ -40,7 +40,7 @@ class DatabaseBackend(BaseDictBackend):
         )
 
         task_name = getattr(request, 'task', None)
-        properties = getattr(request, 'properties') or {}
+        properties = getattr(request, 'properties', {}) or {}
         periodic_task_name = properties.get('periodic_task_name', None)
         worker = getattr(request, 'hostname', None)
 

--- a/django_celery_results/backends/database.py
+++ b/django_celery_results/backends/database.py
@@ -40,7 +40,7 @@ class DatabaseBackend(BaseDictBackend):
         )
 
         task_name = getattr(request, 'task', None)
-        properties = getattr(request, 'properties', {})
+        properties = getattr(request, 'properties') or {}
         periodic_task_name = properties.get('periodic_task_name', None)
         worker = getattr(request, 'hostname', None)
 

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -45,7 +45,7 @@ class test_DatabaseBackend:
         )
         if task_protocol == 1:
             body, headers, _, _ = hybrid_to_proto2(msg, msg.body)
-            properties = {}
+            properties = None
             sent_event = {}
         else:
             headers, properties, body, sent_event = msg


### PR DESCRIPTION
As I can see the value of `properties` should always be a dictionary. For this reason we don't need to handle any falsy values just set it as an empty dictionary if it does not have a valid value.

Fixes #280 