### PR TITLE
Fix field size for MySQL (#285)

### DIFF
--- a/django_celery_results/migrations/0004_auto_20190516_0412.py
+++ b/django_celery_results/migrations/0004_auto_20190516_0412.py
@@ -78,7 +78,16 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='taskresult',
             name='task_name',
-            field=models.CharField(db_index=True, help_text='Name of the Task which was run', max_length=255, null=True, verbose_name='Task Name'),
+            field=models.CharField(
+                db_index=True,
+                help_text='Name of the Task which was run',
+                max_length=getattr(
+                    settings,
+                    'DJANGO_CELERY_RESULTS_TASK_ID_MAX_LENGTH',
+                    255
+                ),
+                null=True,
+                verbose_name='Task Name'),
         ),
         migrations.AlterField(
             model_name='taskresult',

--- a/django_celery_results/migrations/0009_groupresult.py
+++ b/django_celery_results/migrations/0009_groupresult.py
@@ -141,7 +141,11 @@ class Migration(migrations.Migration):
             name='task_name',
             field=models.CharField(
                 help_text='Name of the Task which was run',
-                max_length=255,
+                max_length=getattr(
+                    settings,
+                    'DJANGO_CELERY_RESULTS_TASK_ID_MAX_LENGTH',
+                    255
+                ),
                 null=True,
                 verbose_name='Task Name'),
         ),

--- a/django_celery_results/models.py
+++ b/django_celery_results/models.py
@@ -32,7 +32,11 @@ class TaskResult(models.Model):
         verbose_name=_('Periodic Task Name'),
         help_text=_('Name of the Periodic Task which was run'))
     task_name = models.CharField(
-        null=True, max_length=255,
+        null=True, max_length=getattr(
+            settings,
+            'DJANGO_CELERY_RESULTS_TASK_ID_MAX_LENGTH',
+            255
+        ),
         verbose_name=_('Task Name'),
         help_text=_('Name of the Task which was run'))
     task_args = models.TextField(


### PR DESCRIPTION
MySQL/MariaDB do not accept indexed fields larger than 191 chars when using `utf8mb4` charset. This makes migrations fail because the `task_name` field is 255-chars long and indexed.

This issue was fixed for the `task_id` field using a new `DJANGO_CELERY_RESULTS_TASK_ID_MAX_LENGTH` Django setting. This PR applies the same fix for field `task_name`.