### PR TITLE
fix: The description content type set to RST

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ setuptools.setup(
     version=meta['version'],
     description=meta['doc'],
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type='text/x-rst',
     keywords='celery django database result backend',
     author=meta['author'],
     author_email=meta['contact'],


### PR DESCRIPTION
The long description content type is currently set to markdown so the readme isn't displaying correctly; 
https://pypi.org/project/django-celery-results/

This updates it to RST to match the readme file format.