### PR TITLE
Fix atomic transaction not routing to the the correct DB

### DIFF
--- a/django_celery_results/managers.py
+++ b/django_celery_results/managers.py
@@ -87,7 +87,7 @@ class ResultManager(models.Manager):
 
     def delete_expired(self, expires):
         """Delete all expired results."""
-        with transaction.atomic():
+        with transaction.atomic(using=self.db):
             raw_delete(queryset=self.get_all_expired(expires))
 
 


### PR DESCRIPTION
This to fix the issue explained at: https://github.com/celery/django-celery-results/issues/323