### PR TITLE
fix documentation build failure, fix sphinx errors and amend sphinx warnings

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,10 @@
+version: 2
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.8"
+sphinx:
+   configuration: docs/conf.py
+python:
+   install:
+   - requirements: requirements/docs.txt

--- a/Changelog
+++ b/Changelog
@@ -23,7 +23,7 @@
 :release-date: 2022-04-17 12:50 P.M. UTC+6:00
 :release-by: Asif Saif Uddin
 
-- Remove hard dependency on psycopg2.  
+- Remove hard dependency on psycopg2.
 - Fix #296 Stop producing a universal wheel, python 2 is unspported.
 - fix: The description content type for setuptools needs to be rst to markdown.
 
@@ -35,10 +35,10 @@
 :release-date: 2022-03-01 1:45 p.m. UTC+6:00
 :release-by: Asif Saif Uddin
 
-- Fix default_app_config deprecation (#221)  
+- Fix default_app_config deprecation (#221)
 - Use string values for django-cache keys #230 (#242)
 - feat: raw delete expired instead of Queryset.delete (#235)
-- Fix `pydoc.ErrorDuringImport: problem in django_celery_results url
+- Fix ``pydoc.ErrorDuringImport`` problem in django_celery_results url
 - Russian language support (#255)
 - Add Simplified Chinese translation strings.
 - Minor code clean up
@@ -59,8 +59,8 @@
 :release-date: 2021-07-02 11:00 a.m. UTC+6:00
 :release-by: Asif Saif Uddin
 
-- add new urls with nouns first structure (#216) 
-- Remove duplicate indexes 
+- add new urls with nouns first structure (#216)
+- Remove duplicate indexes
 - fix group status view return data, add tests for it (#215)
 - typo fix (#218)
 - Use the DJANGO_CELERY_RESULTS_TASK_ID_MAX_LENGTH for group_id/task_id
@@ -73,7 +73,7 @@
 :release-date: 2021-06-14 09:00 p.m. UTC+6:00
 :release-by: Asif Saif Uddin
 
-- Don't raise an error when ChordCounter is not found 
+- Don't raise an error when ChordCounter is not found
 - add default_auto_field to apps.py
 - Use the provided chord_size when available
 - Match apply_chord call signature to Celery 5.1
@@ -85,20 +85,20 @@
 2.0.1
 =====
 :release-date: 2021-01-19 07:30 p.m. UTC+6:00
-:release-by: 
+:release-by:
 
 - Fix backward compatibility in DatabaseBackend._store_result function
 - Fix 'args' and 'kwargs' propiertes of AsyncResult for DatabaseBackend
 - Fix task_args/task_kwargs in task_protocol=1
 - Test refactors
-- Add task_args and task_kwargs to admins searchable fields (#182) 
+- Add task_args and task_kwargs to admins searchable fields (#182)
 
 .. _version-2.0.0:
 
 2.0.0
 =====
-:release-date: 
-:release-by: 
+:release-date:
+:release-by:
 
 - Add Spanish translations (#134)
 - Add support for Django 3.0 and 3.1 (#145, #163)

--- a/django_celery_results/managers.py
+++ b/django_celery_results/managers.py
@@ -29,7 +29,6 @@ def transaction_retry(max_retries=1):
     retrying if the operation fails.
 
     Keyword Arguments:
-    -----------------
         max_retries (int): Maximum number of retries.  Default one retry.
 
     """
@@ -92,7 +91,7 @@ class ResultManager(models.Manager):
 
 
 class TaskResultManager(ResultManager):
-    """Manager for :class:`celery.models.TaskResult` models."""
+    """Manager for :class:`~.models.TaskResult` models."""
 
     _last_id = None
 
@@ -100,7 +99,6 @@ class TaskResultManager(ResultManager):
         """Get result for task by ``task_id``.
 
         Keyword Arguments:
-        -----------------
             exception_retry_count (int): How many times to retry by
                 transaction rollback on exception.  This could
                 happen in a race condition if another worker is trying to
@@ -125,7 +123,6 @@ class TaskResultManager(ResultManager):
         """Store the result and status of a task.
 
         Arguments:
-        ---------
             content_type (str): Mime-type of result and meta content.
             content_encoding (str): Type of encoding (e.g. binary/utf-8).
             task_id (str): Id of task.
@@ -145,7 +142,6 @@ class TaskResultManager(ResultManager):
                 children).
 
         Keyword Arguments:
-        -----------------
             exception_retry_count (int): How many times to retry by
                 transaction rollback on exception.  This could
                 happen in a race condition if another worker is trying to
@@ -175,7 +171,7 @@ class TaskResultManager(ResultManager):
 
 
 class GroupResultManager(ResultManager):
-    """Manager for :class:`celery.models.GroupResult` models."""
+    """Manager for :class:`~.models.GroupResult` models."""
 
     _last_id = None
 
@@ -183,7 +179,6 @@ class GroupResultManager(ResultManager):
         """Get result for group by ``group_id``.
 
         Keyword Arguments:
-        -----------------
             exception_retry_count (int): How many times to retry by
                 transaction rollback on exception.  This could
                 happen in a race condition if another worker is trying to

--- a/django_celery_results/models.py
+++ b/django_celery_results/models.py
@@ -157,8 +157,7 @@ class ChordCounter(models.Model):
     )
 
     def group_result(self, app=None):
-        """
-        Return the :class:`celery.result.GroupResult` of self.
+        """Return the :class:`celery.result.GroupResult` of self.
 
         Arguments:
             app (celery.app.base.Celery): app instance to create the

--- a/django_celery_results/models.py
+++ b/django_celery_results/models.py
@@ -161,7 +161,8 @@ class ChordCounter(models.Model):
         Return the :class:`celery.result.GroupResult` of self.
 
         Arguments:
-            app (celery.app.base.Celery): app instance to create the :class:`celery.result.GroupResult` with.
+            app (celery.app.base.Celery): app instance to create the
+               :class:`celery.result.GroupResult` with.
 
         """
         return CeleryGroupResult(

--- a/django_celery_results/models.py
+++ b/django_celery_results/models.py
@@ -157,11 +157,11 @@ class ChordCounter(models.Model):
     )
 
     def group_result(self, app=None):
-        """Return the GroupResult of self.
+        """
+        Return the :class:`celery.result.GroupResult` of self.
 
         Arguments:
-        ---------
-            app (Celery): app instance to create the GroupResult with.
+            app (celery.app.base.Celery): app instance to create the :class:`celery.result.GroupResult` with.
 
         """
         return CeleryGroupResult(

--- a/docs/copyright.rst
+++ b/docs/copyright.rst
@@ -11,7 +11,7 @@ Copyright |copy| 2016, Ask Solem
 
 All rights reserved.  This material may be copied or distributed only
 subject to the terms and conditions set forth in the `Creative Commons
-Attribution-ShareAlike 4.0 International`
+Attribution-ShareAlike 4.0 International
 <http://creativecommons.org/licenses/by-sa/4.0/legalcode>`_ license.
 
 You may share and adapt the material, even for commercial purposes, but

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -54,11 +54,9 @@ To use :pypi:`django-celery-results` with your project you need to follow these 
                 'LOCATION': 'my_cache_table',
             }
         }
-        
-    If you want to include extended information about your tasks remember to enable the `result_extended` setting. 
-    More information here: https://docs.celeryq.dev/en/stable/userguide/configuration.html#result-extended
-    
-    .. code-block:: python
-        
-        CELERY_RESULT_EXTENDED = True
 
+    If you want to include extended information about your tasks remember to enable the :setting:`result_extended` setting.
+
+    .. code-block:: python
+
+        CELERY_RESULT_EXTENDED = True

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -9,21 +9,14 @@ About
 
 This extension enables you to store Celery task and group results using the Django ORM.
 
-It defines 2 models (``django_celery_results.models.TaskResult`` and ``django_celery_results.models.GroupResult``)
+It defines 2 models (:class:`django_celery_results.models.TaskResult` and :class:`django_celery_results.models.GroupResult`)
 used to store task and group results, and you can query these database tables like
 any other Django model.
 
-If your `django-celery-beat` carries `request["properties"]["periodic_task_name"]`,
-it will be stored in `TaskResult.periodic_task_name` to track the periodic task.
+If your ``django-celery-beat`` carries ``request["properties"]["periodic_task_name"]``,
+it will be stored in :attr:`TaskResult.periodic_task_name <django_celery_results.models.TaskResult.periodic_task_name>` to track the periodic task.
 
 Installing
 ==========
 
-The installation instructions for this extension is available
-from the `Celery documentation`_:
-
-http://docs.celeryproject.org/en/latest/django/first-steps-with-django.html#django-celery-results-using-the-django-orm-cache-as-a-result-backend
-
-
-.. _`Celery documentation`:
-    http://docs.celeryproject.org/en/latest/django/first-steps-with-django.html#django-celery-results-using-the-django-orm-cache-as-a-result-backend
+The installation instructions for this extension is available from the :ref:`Celery documentation <django-celery-results>`.

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -13,7 +13,7 @@ It defines 2 models (:class:`django_celery_results.models.TaskResult` and :class
 used to store task and group results, and you can query these database tables like
 any other Django model.
 
-If your ``django-celery-beat`` carries ``request["properties"]["periodic_task_name"]``,
+If your :pypi:`django-celery-beat` carries ``request["properties"]["periodic_task_name"]``,
 it will be stored in :attr:`TaskResult.periodic_task_name <django_celery_results.models.TaskResult.periodic_task_name>` to track the periodic task.
 
 Installing

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,2 +1,3 @@
 sphinx_celery>=1.1
 Django>=2.2
+celery>=5.2.3,<6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,8 @@ markers =
 ignore = N806, N802, N801, N803
 
 [pep257]
-ignore = D102,D104,D203,D105,D213
+convention=google
+add-ignore = D102,D104,D203,D105,D213
 match-dir = [^migrations]
 
 [isort]


### PR DESCRIPTION
This PR is similar to https://github.com/celery/django-celery-beat/pull/527: failing doc build is healed so the documentation hosted under https://django-celery-results.readthedocs.io/en/latest/ should update now. Also fixed Sphinx errors and (most) warnings.

Built result: [django-celery-results-pr docs](https://django-celery-results-pr.readthedocs.io/en/latest/).