### PR TITLE
add custom expires filter

### DIFF
--- a/django_celery_results/backends/database.py
+++ b/django_celery_results/backends/database.py
@@ -179,7 +179,7 @@ class DatabaseBackend(BaseDictBackend):
 
     def cleanup(self):
         """Delete expired metadata."""
-        self.TaskModel._default_manager.delete_expired(self.expires)
+        self.TaskModel._default_manager.delete_expired(self.expires, self.app)
         self.GroupModel._default_manager.delete_expired(self.expires)
 
     def _restore_group(self, group_id):

--- a/django_celery_results/managers.py
+++ b/django_celery_results/managers.py
@@ -83,11 +83,21 @@ class ResultManager(models.Manager):
     def get_all_expired(self, expires):
         """Get all expired results."""
         return self.filter(date_done__lt=now() - maybe_timedelta(expires))
+    
+    
+    def get_all_expired(self, expires, app):
+        """Get all expired task results."""
+        if app.conf.expires_filters_args or app.conf.expires_filters_kwargs:
+            return self.filter(
+                *app.conf.expires_filters_args,
+                **app.conf.expires_filters_kwargs)
+        return self.filter(date_done__lt=now() - maybe_timedelta(expires))
+
 
     def delete_expired(self, expires):
         """Delete all expired results."""
         with transaction.atomic(using=self.db):
-            raw_delete(queryset=self.get_all_expired(expires))
+            raw_delete(queryset=self.get_all_expired(expires, app))
 
 
 class TaskResultManager(ResultManager):


### PR DESCRIPTION
This PR lets developers can custom expired tasks by adding two configuration properties
- `expires_filters_args`: a tuple of arguments
- `expires_filters_kwargs`: a dictionary of keyword arguments.

This feature is useful when we have important tasks and want to keep them in the database longer than other tasks.

