### PR TITLE
Only update the ChordCounter.count field when saving

### DIFF
--- a/django_celery_results/backends/database.py
+++ b/django_celery_results/backends/database.py
@@ -246,7 +246,7 @@ class DatabaseBackend(BaseDictBackend):
                 return
             chord_counter.count -= 1
             if chord_counter.count != 0:
-                chord_counter.save()
+                chord_counter.save(update_fields=["count"])
             else:
                 # Last task in the chord header has finished
                 call_callback = True


### PR DESCRIPTION
With the current implementation the following SQL query will be continually executed on every task:

```sql
UPDATE "django_celery_results_chordcounter" 
SET "group_id" = 'f81ac317-eb61-42a6-a750-7cc1feb78b8c', 
"sub_tasks" = '[[["6a2f07d8-6b6f-4286-9d71-dbead46e9b1c", null], null], ..', 
"count" = 122 
WHERE "django_celery_results_chordcounter"."id" = 118
```

If you are using a large number of sub-tasks, ranging in the thousands or tens of thousands, then continually sending the `sub_tasks` in every update can be very expensive.

If we use `update_fields` then we can skip this.