### PR TITLE
Update CI to refer to main

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,10 +2,10 @@ name: Test
 
 on:
     pull_request:
-        branches: [ "master" ]
+        branches: [ "main" ]
 
     push:
-        branches: ["master"]
+        branches: [ "main" ]
 
 jobs:
     matrix:


### PR DESCRIPTION
We renamed the master branch to main.
We need to adjust the CI workflow.
This PR does just that.