### PR TITLE
Meta injection

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,8 +9,9 @@ Contents
 
 .. toctree::
     :maxdepth: 1
-    
+
     getting_started
+    injecting_metadata
     copyright
 
 .. toctree::

--- a/docs/injecting_metadata.rst
+++ b/docs/injecting_metadata.rst
@@ -1,0 +1,17 @@
+Injecting metadata
+===============
+
+To save arbitrary data on the field TaskResult.meta, the Celery Task Request must be manipulated as such:
+
+    .. code-block:: python
+
+        from celery import Celery
+
+        app = Celery('hello', broker='amqp://guest@localhost//')
+
+        @app.task(bind=True)
+        def hello(task_instance):
+            task_instance.request.meta = {'some_key': 'some_value'}
+            return 'hello world'
+
+This way, the value of ``task_instance.request.meta`` will be stored on ``TaskResult.meta``.

--- a/docs/injecting_metadata.rst
+++ b/docs/injecting_metadata.rst
@@ -1,6 +1,7 @@
 Injecting metadata
 ===============
 
+
 To save arbitrary data on the field TaskResult.meta, the Celery Task Request must be manipulated as such:
 
     .. code-block:: python
@@ -12,6 +13,29 @@ To save arbitrary data on the field TaskResult.meta, the Celery Task Request mus
         @app.task(bind=True)
         def hello(task_instance):
             task_instance.request.meta = {'some_key': 'some_value'}
+            task_instance.update_state(
+                state='PROGRESS',
+                meta='Task current result'
+            )
+            # If TaskResult is queried from DB at this momento it will yield
+            # TaskResult(
+            #     result='Task current result',
+            #     meta={'some_key': 'some_value'}  # some discrepancies apply as I didn't document the json parse and children data
+            # )
             return 'hello world'
+        
+        # After task is completed, if TaskResult is queried from DB at this momento it will yield
+        # TaskResult(
+        #     result='hello world',
+        #     meta={'some_key': 'some_value'}  # some discrepancies apply as I didn't document the json parse and children data
+        # )
 
 This way, the value of ``task_instance.request.meta`` will be stored on ``TaskResult.meta``.
+
+Note that the `meta` arg in the method `update_state` is not really a metadata and it's not stored on ``TaskResult.meta``.
+This arg is used to save the CURRENT result of the task. So it's stored on ``TaskResult.result``.
+
+It works this way because while a task is executing, the TaskResult is used really as current task state; holding information, temporarily, until the task completes.
+Subsequent calls calls to update_state update the same TaskResult, overwriting what was there previously.
+Upon completion of the task, the results of the task are stored in the same TaskResult, overwriting the previous state of the task. So the return from the function is stored in ``TaskResult.result`` and ``TaskResult.status`` is set to 'SUCCESS' (or 'FAILURE').
+

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -517,6 +517,38 @@ class test_DatabaseBackend:
         assert json.loads(tr.task_args) == ['a', 1, True]
         assert json.loads(tr.task_kwargs) == {'c': 6, 'd': 'e', 'f': False}
 
+    def test_backend__task_result_meta_injection(self):
+        self.app.conf.result_serializer = 'json'
+        self.app.conf.accept_content = {'pickle', 'json'}
+        self.b = DatabaseBackend(app=self.app)
+
+        tid2 = uuid()
+        request = self._create_request(
+            task_id=tid2,
+            name='my_task',
+            args=[],
+            kwargs={},
+            task_protocol=1,
+        )
+        result = None
+
+        # inject request meta arbitrary data
+        request.meta = {
+            'some_key': 'some_value'
+        }
+
+        self.b.mark_as_done(tid2, result, request=request)
+        mindb = self.b.get_task_meta(tid2)
+
+        # check task meta
+        assert mindb.get('result') is None
+        assert mindb.get('task_name') == 'my_task'
+        assert mindb.get('meta') == {'some_key': 'some_value'}
+
+        # check task_result object
+        tr = TaskResult.objects.get(task_id=tid2)
+        assert json.loads(tr.meta) == {}
+
     def xxx_backend(self):
         tid = uuid()
 


### PR DESCRIPTION
# Resume
- related to #37 

The issue #37 points to save data using the arg `meta` from the method `update_state`, but the `meta` attribute is renamed to `result` when it is passed to `self.backend.store_result`.

As explained here in this comment https://github.com/celery/django-celery-results/issues/37#issuecomment-385203222.

> https://github.com/celery/celery/blob/cb4c3256326e33f005c63d48520d0abb5e898151/celery/app/task.py#L982-L994
```python
    def update_state(self, task_id=None, state=None, meta=None, **kwargs):
        """Update task state.

        Arguments:
            task_id (str): Id of the task to update.
                Defaults to the id of the current task.
            state (str): New state.
            meta (Dict): State meta-data.
        """
        if task_id is None:
            task_id = self.request.id
        self.backend.store_result(
            task_id, meta, state, request=self.request, **kwargs)
```

> https://github.com/celery/celery/blob/cb4c3256326e33f005c63d48520d0abb5e898151/celery/backends/base.py#L513-L522
```python
    def store_result(self, task_id, result, state,
                     traceback=None, request=None, **kwargs):
        """Update task state and result.

        if always_retry_backend_operation is activated, in the event of a recoverable exception,
        then retry operation with an exponential backoff until a limit has been reached.
        """
        result = self.encode_result(result, state)


        retries = 0
```


# Problem
So the argued `meta` arg on `store_result` is not really arbitrary metadata. It's actually the result of the Task.

# Solution
Use the TaskResult.meta to store arbitrary data.

# How to inject?
I implemented the meta injection through the Task Celery Request. This way I don't mess around with too many implementations and function signatures. 
