### PR TITLE
Document `track_started` setting

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -60,3 +60,9 @@ To use :pypi:`django-celery-results` with your project you need to follow these 
     .. code-block:: python
 
         CELERY_RESULT_EXTENDED = True
+
+    If you want to track the execution duration of your tasks (by comparing `date_created` and `date_done` in TaskResult), enable the :setting:`track_started` setting.
+    
+    .. code-block:: python
+
+        CELERY_TASK_TRACK_STARTED = True


### PR DESCRIPTION
Explicitly reference the `track_started` setting to highlight the fact that task execution duration can not be obtained from a task result's `date_created` and `date_done` without a configuration change.