### PR TITLE
Add additional project URLs to PyPI metadata (docs, changelog, repo)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -139,6 +139,16 @@ setuptools.setup(
     author=meta['author'],
     author_email=meta['contact'],
     url=meta['homepage'],
+    project_urls={
+        'Documentation': (
+            'https://django-celery-results.readthedocs.io/en/latest/'
+        ),
+        'Changelog': (
+            'https://django-celery-results.readthedocs.io/en/latest/'
+            'changelog.html'
+        ),
+        'Repository': 'https://github.com/celery/django-celery-results',
+    },
     platforms=['any'],
     license='BSD',
     classifiers=classifiers,


### PR DESCRIPTION
These links will be visible on the package's PyPI page, [example](https://pypi.org/project/sentry-sdk/):

> ![image](https://user-images.githubusercontent.com/137616/228550059-2466757b-6edf-43b5-a5f1-0b49690e1b66.png)

Additionally, tools like Renovate bot use these links to provide quicker access to the changelog for a dependency update, and can call GitHub API for additional metadata. Specifically it recognizes `Changelog` and `Repository`.
