### PR TITLE
Ensure triggering of callback in chord

### DIFF
--- a/django_celery_results/backends/database.py
+++ b/django_celery_results/backends/database.py
@@ -265,7 +265,6 @@ class DatabaseBackend(BaseDictBackend):
             else:
                 # Last task in the chord header has finished
                 call_callback = True
-                chord_counter.delete()
 
         if call_callback:
             deps = chord_counter.group_result(app=self.app)
@@ -276,6 +275,9 @@ class DatabaseBackend(BaseDictBackend):
                     callback=callback,
                     group_result=deps
                 )
+                chord_counter.delete()
+            else:
+                logger.warning("ChordCounter for Group %s 0 but not ready yet.", gid)
 
 
 def trigger_callback(app, callback, group_result):

--- a/django_celery_results/backends/database.py
+++ b/django_celery_results/backends/database.py
@@ -277,7 +277,8 @@ class DatabaseBackend(BaseDictBackend):
                 )
                 chord_counter.delete()
             else:
-                logger.warning("ChordCounter for Group %s 0 but not ready yet.", gid)
+                logger.warning("ChordCounter for Group %s 0 "
+                               "but not ready yet.", gid)
 
 
 def trigger_callback(app, callback, group_result):


### PR DESCRIPTION
If one task for whatever reason is executed twice the callback is never triggered because the chord will be deleted before the last task is executed. The last task will then raise a warning that the chord can't be found.