### PR TITLE
update behavior of app.result_expires to match celery docs

### DIFF
--- a/django_celery_results/backends/database.py
+++ b/django_celery_results/backends/database.py
@@ -194,6 +194,8 @@ class DatabaseBackend(BaseDictBackend):
 
     def cleanup(self):
         """Delete expired metadata."""
+        if not self.expires:
+            return
         self.TaskModel._default_manager.delete_expired(self.expires)
         self.GroupModel._default_manager.delete_expired(self.expires)
 


### PR DESCRIPTION
[Celery documentation](https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-result_expires) indicates that app.result_expires (or CELERY_RESULT_EXPIRES) should respect values of 0 or None: "A value of None or 0 means results will never expire (depending on backend specifications)."
