### PR TITLE
Fix atomic transaction not routing to the the correct DB in DatabaseBackend.on_chord_part_return transaction.atomic

### DIFF
--- a/django_celery_results/backends/database.py
+++ b/django_celery_results/backends/database.py
@@ -246,7 +246,7 @@ class DatabaseBackend(BaseDictBackend):
         if not gid or not tid:
             return
         call_callback = False
-        with transaction.atomic():
+        with transaction.atomic(using=ChordCounter.objects.db):
             # We need to know if `count` hits 0.
             # wrap the update in a transaction
             # with a `select_for_update` lock to prevent race conditions.

--- a/django_celery_results/backends/database.py
+++ b/django_celery_results/backends/database.py
@@ -7,7 +7,7 @@ from celery.exceptions import ChordError
 from celery.result import GroupResult, allow_join_result, result_from_tuple
 from celery.utils.log import get_logger
 from celery.utils.serialization import b64decode, b64encode
-from django.db import connection, transaction
+from django.db import connection, router, transaction
 from django.db.utils import InterfaceError
 from kombu.exceptions import DecodeError
 
@@ -246,7 +246,7 @@ class DatabaseBackend(BaseDictBackend):
         if not gid or not tid:
             return
         call_callback = False
-        with transaction.atomic(using=ChordCounter.objects.db):
+        with transaction.atomic(using=router.db_for_write(ChordCounter)):
             # We need to know if `count` hits 0.
             # wrap the update in a transaction
             # with a `select_for_update` lock to prevent race conditions.

--- a/t/proj/settings.py
+++ b/t/proj/settings.py
@@ -32,6 +32,7 @@ try:
             'NAME': 'postgres',
             'USER': 'postgres',
             'PASSWORD': 'postgres',
+            "PORT": 5434,
             'OPTIONS': {
                 'connect_timeout': 1000,
             }
@@ -42,6 +43,7 @@ try:
             'NAME': 'postgres',
             'USER': 'postgres',
             'PASSWORD': 'postgres',
+            "PORT": 5434,
             'OPTIONS': {
                 'connect_timeout': 1000,
             },
@@ -49,6 +51,21 @@ try:
                 'MIRROR': 'default',
             },
         },
+        'read-only': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'HOST': 'localhost',
+            'NAME': 'read-only-database',
+            'USER': 'postgres',
+            'PASSWORD': 'postgres',
+            "PORT": 5434,
+            'OPTIONS': {
+                'connect_timeout': 1000,
+                'options': '-c default_transaction_read_only=on',
+            },
+            'TEST': {
+                'MIRROR': 'default',
+            },
+        }
     }
 except ImportError:
     DATABASES = {
@@ -66,6 +83,13 @@ except ImportError:
                 'timeout': 1000,
             }
         },
+        'read-only': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+            'OPTIONS': {
+                'timeout': 1000,
+            }
+        }
     }
 
 # Quick-start development settings - unsuitable for production

--- a/t/proj/settings.py
+++ b/t/proj/settings.py
@@ -32,7 +32,6 @@ try:
             'NAME': 'postgres',
             'USER': 'postgres',
             'PASSWORD': 'postgres',
-            "PORT": 5434,
             'OPTIONS': {
                 'connect_timeout': 1000,
             }
@@ -43,7 +42,6 @@ try:
             'NAME': 'postgres',
             'USER': 'postgres',
             'PASSWORD': 'postgres',
-            "PORT": 5434,
             'OPTIONS': {
                 'connect_timeout': 1000,
             },
@@ -57,7 +55,6 @@ try:
             'NAME': 'read-only-database',
             'USER': 'postgres',
             'PASSWORD': 'postgres',
-            "PORT": 5434,
             'OPTIONS': {
                 'connect_timeout': 1000,
                 'options': '-c default_transaction_read_only=on',

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -782,10 +782,11 @@ class test_DatabaseBackend:
         request.group = uuid()
         self.b.on_chord_part_return(request=request, state=None, result=None)
 
-    @pytest.mark.django_db(databases=['default', 'read'])
     def test_on_chord_part_return_multiple_databases(self):
-        """Test if the ChordCounter is properly decremented and the callback is
-        triggered after all chord parts have returned with multiple databases"""
+        """
+        Test if the ChordCounter is properly decremented and the callback is
+        triggered after all chord parts have returned with multiple databases
+        """
         gid = uuid()
         tid1 = uuid()
         tid2 = uuid()
@@ -793,7 +794,9 @@ class test_DatabaseBackend:
         group = GroupResult(id=gid, results=subtasks)
         self.b.apply_chord(group, self.add.s())
 
-        chord_counter = ChordCounter.objects.using("read").get(group_id=gid)
+        chord_counter = ChordCounter.objects.using(
+            "secondary"
+        ).get(group_id=gid)
         assert chord_counter.count == 2
 
         request = mock.MagicMock()
@@ -817,7 +820,7 @@ class test_DatabaseBackend:
         self.b.mark_as_done(tid2, result, request=request)
 
         with pytest.raises(ChordCounter.DoesNotExist):
-            ChordCounter.objects.using("read").get(group_id=gid)
+            ChordCounter.objects.using("secondary").get(group_id=gid)
 
         request.chord.delay.assert_called_once()
 

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -11,6 +11,7 @@ from celery.result import AsyncResult, GroupResult
 from celery.utils.serialization import b64decode
 from celery.worker.request import Request
 from celery.worker.strategy import hybrid_to_proto2
+from django.test import TransactionTestCase
 
 from django_celery_results.backends.database import DatabaseBackend
 from django_celery_results.models import ChordCounter, TaskResult
@@ -782,48 +783,6 @@ class test_DatabaseBackend:
         request.group = uuid()
         self.b.on_chord_part_return(request=request, state=None, result=None)
 
-    def test_on_chord_part_return_multiple_databases(self):
-        """
-        Test if the ChordCounter is properly decremented and the callback is
-        triggered after all chord parts have returned with multiple databases
-        """
-        gid = uuid()
-        tid1 = uuid()
-        tid2 = uuid()
-        subtasks = [AsyncResult(tid1), AsyncResult(tid2)]
-        group = GroupResult(id=gid, results=subtasks)
-        self.b.apply_chord(group, self.add.s())
-
-        chord_counter = ChordCounter.objects.using(
-            "secondary"
-        ).get(group_id=gid)
-        assert chord_counter.count == 2
-
-        request = mock.MagicMock()
-        request.id = subtasks[0].id
-        request.group = gid
-        request.task = "my_task"
-        request.args = ["a", 1, "password"]
-        request.kwargs = {"c": 3, "d": "e", "password": "password"}
-        request.argsrepr = "argsrepr"
-        request.kwargsrepr = "kwargsrepr"
-        request.hostname = "celery@ip-0-0-0-0"
-        request.properties = {"periodic_task_name": "my_periodic_task"}
-        request.ignore_result = False
-        result = {"foo": "baz"}
-
-        self.b.mark_as_done(tid1, result, request=request)
-
-        chord_counter.refresh_from_db()
-        assert chord_counter.count == 1
-
-        self.b.mark_as_done(tid2, result, request=request)
-
-        with pytest.raises(ChordCounter.DoesNotExist):
-            ChordCounter.objects.using("secondary").get(group_id=gid)
-
-        request.chord.delay.assert_called_once()
-
     def test_callback_failure(self):
         """Test if a failure in the chord callback is properly handled"""
         gid = uuid()
@@ -961,3 +920,57 @@ class test_DatabaseBackend:
         tr = TaskResult.objects.get(task_id=tid2)
         assert tr.task_args is None
         assert tr.task_kwargs is None
+
+
+class ChordPartReturnTestCase(TransactionTestCase):
+    databases = "__all__"
+
+    def setUp(self):
+        super().setUp()
+        self.app.conf.result_serializer = 'json'
+        self.app.conf.result_backend = (
+            'django_celery_results.backends:DatabaseBackend')
+        self.app.conf.result_extended = True
+        self.b = DatabaseBackend(app=self.app)
+
+    def test_on_chord_part_return_multiple_databases(self):
+        """
+        Test if the ChordCounter is properly decremented and the callback is
+        triggered after all chord parts have returned with multiple databases
+        """
+        gid = uuid()
+        tid1 = uuid()
+        tid2 = uuid()
+        subtasks = [AsyncResult(tid1), AsyncResult(tid2)]
+        group = GroupResult(id=gid, results=subtasks)
+        self.b.apply_chord(group, self.add.s())
+
+        chord_counter = ChordCounter.objects.using(
+            "secondary"
+        ).get(group_id=gid)
+        assert chord_counter.count == 2
+
+        request = mock.MagicMock()
+        request.id = subtasks[0].id
+        request.group = gid
+        request.task = "my_task"
+        request.args = ["a", 1, "password"]
+        request.kwargs = {"c": 3, "d": "e", "password": "password"}
+        request.argsrepr = "argsrepr"
+        request.kwargsrepr = "kwargsrepr"
+        request.hostname = "celery@ip-0-0-0-0"
+        request.properties = {"periodic_task_name": "my_periodic_task"}
+        request.ignore_result = False
+        result = {"foo": "baz"}
+
+        self.b.mark_as_done(tid1, result, request=request)
+
+        chord_counter.refresh_from_db()
+        assert chord_counter.count == 1
+
+        self.b.mark_as_done(tid2, result, request=request)
+
+        with pytest.raises(ChordCounter.DoesNotExist):
+            ChordCounter.objects.using("secondary").get(group_id=gid)
+
+        request.chord.delay.assert_called_once()


### PR DESCRIPTION
Hi,
 when using chord with Database result backend and multiple databases with a Database Router we encounter this error:
`select_for_update cannot be used outside of a transaction.`
This depends on the fact that in DatabaseBackend.on_chord_part_return a transaction.atomic is created on the default database and not on the one associated with ChordCounter.

We write this simple fix for handle also this case.

Setting we configured:

```
DATABASES = {
    "default": {
        "ENGINE": "django.db.backends.postgresql",
        "NAME": "data",
    },
    "celery_result": {
        "ENGINE": "django.db.backends.postgresql",
        "NAME": "results",
    },
}
DATABASE_ROUTERS = [
    "app.db_routers.DjangoCeleryResultRouter",
]
```

Router class:

```
class DjangoCeleryResultRouter:
    route_app_labels = {"django_celery_results"}

    def db_for_read(self, model, **hints):
        if model._meta.app_label in self.route_app_labels:
            return "celery_result"
        return None

    def db_for_write(self, model, **hints):
        if model._meta.app_label in self.route_app_labels:
            return "celery_result"
        return None

    def allow_relation(self, obj1, obj2, **hints):
        if obj1._meta.app_label in self.route_app_labels or obj2._meta.app_label in self.route_app_labels:
            return True
        return None

    def allow_migrate(self, db, app_label, model_name=None, **hints):
        if app_label in self.route_app_labels:
            return db == "celery_result"
        return None
```

 