### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ The installation instructions for this extension is available
 from the `Celery documentation`_
 
 .. _`Celery documentation`:
-    https://docs.celeryproject.org/en/latest/django/first-steps-with-django.html#django-celery-results-using-the-django-orm-cache-as-a-result-backend
+    https://docs.celeryq.dev/en/latest/django/first-steps-with-django.html#django-celery-results-using-the-django-orm-cache-as-a-result-backendresults-using-the-django-orm-cache-as-a-result-backend
 
 .. _installation:
 

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ The installation instructions for this extension is available
 from the `Celery documentation`_
 
 .. _`Celery documentation`:
-    https://docs.celeryq.dev/en/latest/django/first-steps-with-django.html#django-celery-results-using-the-django-orm-cache-as-a-result-backendresults-using-the-django-orm-cache-as-a-result-backend
+    https://docs.celeryq.dev/en/latest/django/first-steps-with-django.html#django-celery-results-using-the-django-orm-cache-as-a-result-backend
 
 .. _installation:
 


### PR DESCRIPTION
Updated the URL pointing to Celery's documentation to the new address (celeryproject.org -> celeryq.dev). The old address was 404'ing.