### PR TITLE
Added extra except clause to TryRemoveIndex

### DIFF
--- a/django_celery_results/migrations/0010_remove_duplicate_indices.py
+++ b/django_celery_results/migrations/0010_remove_duplicate_indices.py
@@ -21,6 +21,10 @@ class TryRemoveIndex(migrations.RemoveIndex):
             super().database_forwards(*args, **kwargs)
         except DatabaseError:
             pass
+        except Exception:
+            # Not all DB engines throw DatabaseError when the
+            #   index does not exist.
+            pass
 
     def database_backwards(self, *args, **kwargs):
         """Don't re-add the index when reverting this migration"""


### PR DESCRIPTION
I have been experiencing the following issue, when using django-celery-results with SQLite:

```
Applying django_celery_results.0008_chordcounter... OK
  Applying django_celery_results.0009_groupresult... OK
  Applying django_celery_results.0010_remove_duplicate_indices...Traceback (most recent call last):
  File "/opt/ldr/app/./manage.py", line 26, in <module>
    main()
  File "/opt/ldr/app/./manage.py", line 22, in main
    execute_from_command_line(sys.argv)
  File "/opt/ldr/.venv/lib/python3.12/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/opt/ldr/.venv/lib/python3.12/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/opt/ldr/.venv/lib/python3.12/site-packages/django/core/management/base.py", line 413, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/opt/ldr/.venv/lib/python3.12/site-packages/django/core/management/base.py", line 459, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/ldr/.venv/lib/python3.12/site-packages/django/core/management/base.py", line 107, in wrapper
    res = handle_func(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/ldr/.venv/lib/python3.12/site-packages/django/core/management/commands/migrate.py", line 357, in handle
    post_migrate_state = executor.migrate(
                         ^^^^^^^^^^^^^^^^^
  File "/opt/ldr/.venv/lib/python3.12/site-packages/django/db/migrations/executor.py", line 135, in migrate
    state = self._migrate_all_forwards(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/ldr/.venv/lib/python3.12/site-packages/django/db/migrations/executor.py", line 167, in _migrate_all_forwards
    state = self.apply_migration(
            ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/ldr/.venv/lib/python3.12/site-packages/django/db/migrations/executor.py", line 255, in apply_migration
    state = migration.apply(state, schema_editor)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/ldr/.venv/lib/python3.12/site-packages/django/db/migrations/migration.py", line 132, in apply
    operation.database_forwards(
  File "/opt/ldr/.venv/lib/python3.12/site-packages/django_celery_results/migrations/0010_remove_duplicate_indices.py", line 21, in database_forwards
    super().database_forwards(*args, **kwargs)
  File "/opt/ldr/.venv/lib/python3.12/site-packages/django/db/migrations/operations/models.py", line 971, in database_forwards
    schema_editor.remove_index(model, index)
  File "/opt/ldr/.venv/lib/python3.12/site-packages/django/db/backends/base/schema.py", line 571, in remove_index
    self.execute(index.remove_sql(model, self))
  File "/opt/ldr/.venv/lib/python3.12/site-packages/django/db/backends/base/schema.py", line 202, in execute
    cursor.execute(sql, params)
  File "/opt/ldr/app/contrib/ldr_legacy/readonly/cursor.py", line 119, in execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/ldr/app/contrib/ldr_legacy/readonly/cursor.py", line 71, in execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/ldr/.venv/lib/python3.12/site-packages/django/db/backends/sqlite3/base.py", line 354, in execute
    return super().execute(query, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pysqlite3.dbapi2.OperationalError: no such index: django_cele_group_i_299b0d_idx
```

It appears the following except clause does not catch the pysqlite OperationError:
```python

class TryRemoveIndex(migrations.RemoveIndex):
    """Operation to remove the Index
    without reintroducing it on reverting the migration
    """

    def database_forwards(self, *args, **kwargs):
        """Remove the index on the database if it exists"""
        try:
            super().database_forwards(*args, **kwargs)
        except DatabaseError:
            pass
            
    ...            
```
