### PR TITLE
Fix for missing periodic task name

### DIFF
--- a/django_celery_results/backends/database.py
+++ b/django_celery_results/backends/database.py
@@ -87,8 +87,8 @@ class DatabaseBackend(BaseDictBackend):
             if task_kwargs is not None:
                 _, _, task_kwargs = self.encode_content(task_kwargs)
 
-            properties = getattr(request, 'properties', {}) or {}
-            periodic_task_name = properties.get('periodic_task_name', None)
+            periodic_task_name = getattr(request, 'periodic_task_name', None)
+
             extended_props.update({
                 'periodic_task_name': periodic_task_name,
                 'task_args': task_args,


### PR DESCRIPTION
Fix for issue [#376](https://github.com/celery/django-celery-results/issues/376). The message broker Rabbitmq isn't picking up the `periodic_task_name` when it's passed as a keyword arg to `task.apply_async()` in django-celery-beat. If it's added to the `headers` in `apply_async()` it becomes available in the `request` object in django-celery-results. For this change to work the following [commit](https://github.com/celery/django-celery-beat/commit/3ab299e8f7d46fc95a22ac1a0cf823b1e7d8b009) also needs to be merged, otherwise it won't get passed by django-celery-beat. 

If the task isn't triggered by django-celery-beat, but is done with code, such as using `delay()` or `apply_async()`, it will be missing, unless it's added to the headers in [`apply_async()`](https://docs.celeryq.dev/en/stable/reference/celery.app.task.html#celery.app.task.Task.apply_async). [delay()](https://docs.celeryq.dev/en/stable/reference/celery.app.task.html#celery.app.task.Task.delay) doesn't support the extra options. E.g. When triggering a child task with `delay()` Periodic Task Name was missing in the Task Results. 

These changes haven't been tested with Redis or any other message broker, only rabbitmq. `CELERY_RESULT_EXTENDED` was set to `True` in the settings.
Tested with: 
celery==5.4.0 
django-celery-beat==2.7.0 
django-celery-results==2.5.1
Django==4.2.16
rabbitmq==4.0.2