### PR TITLE
PoC: Remove case dependency and use Celery fixture

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,4 @@
+--no-binary celery
 pytest>=6.2.5,<8
 pytest-django>=4.5.2
 pytest-benchmark

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,3 @@
-case>=1.3.1
 pytest>=6.2.5,<8
 pytest-django>=4.5.2
 pytest-benchmark

--- a/t/conftest.py
+++ b/t/conftest.py
@@ -12,11 +12,12 @@ from celery.contrib.pytest import (
     use_celery_app_trap,
 )
 from celery.contrib.testing.app import TestApp, Trap
+from celery.t.conftest import patching
 
 # Tricks flake8 into silencing redefining fixtures warnings.
 __all__ = (
     'celery_app', 'celery_enable_logging', 'depends_on_current_app',
-    'celery_parameters', 'celery_config', 'use_celery_app_trap'
+    'celery_parameters', 'celery_config', 'use_celery_app_trap', 'patching'
 )
 
 


### PR DESCRIPTION
Extracted from https://github.com/celery/django-celery-results/pull/458 as `case` does not support Python 3.12/3.13