### PR TITLE
Remove case dependency and copy Celery fixture

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,3 @@
-case>=1.3.1
 pytest>=6.2.5,<8
 pytest-django>=4.5.2
 pytest-benchmark

--- a/t/conftest.py
+++ b/t/conftest.py
@@ -1,3 +1,8 @@
+import sys
+import types
+from contextlib import contextmanager
+from unittest.mock import MagicMock, Mock, patch
+
 import pytest
 
 # we have to import the pytest plugin fixtures here,
@@ -20,6 +25,9 @@ __all__ = (
 )
 
 
+SENTINEL = object()
+
+
 @pytest.fixture(scope='session', autouse=True)
 def setup_default_app_trap():
     from celery._state import set_default_app
@@ -29,6 +37,117 @@ def setup_default_app_trap():
 @pytest.fixture()
 def app(celery_app):
     return celery_app
+
+
+@contextmanager
+def module_context_manager(*names):
+    """Mock one or modules such that every attribute is a :class:`Mock`."""
+    yield from _module(*names)
+
+
+def _module(*names):
+    prev = {}
+
+    class MockModule(types.ModuleType):
+
+        def __getattr__(self, attr):
+            setattr(self, attr, Mock())
+            return types.ModuleType.__getattribute__(self, attr)
+
+    mods = []
+    for name in names:
+        try:
+            prev[name] = sys.modules[name]
+        except KeyError:
+            pass
+        mod = sys.modules[name] = MockModule(name)
+        mods.append(mod)
+    try:
+        yield mods
+    finally:
+        for name in names:
+            try:
+                sys.modules[name] = prev[name]
+            except KeyError:
+                try:
+                    del sys.modules[name]
+                except KeyError:
+                    pass
+
+
+class _patching:
+
+    def __init__(self, monkeypatch, request):
+        self.monkeypatch = monkeypatch
+        self.request = request
+
+    def __getattr__(self, name):
+        return getattr(self.monkeypatch, name)
+
+    def __call__(self, path, value=SENTINEL, name=None,
+                 new=MagicMock, **kwargs):
+        value = self._value_or_mock(value, new, name, path, **kwargs)
+        self.monkeypatch.setattr(path, value)
+        return value
+
+    def object(self, target, attribute, *args, **kwargs):
+        return _wrap_context(
+            patch.object(target, attribute, *args, **kwargs),
+            self.request)
+
+    def _value_or_mock(self, value, new, name, path, **kwargs):
+        if value is SENTINEL:
+            value = new(name=name or path.rpartition('.')[2])
+        for k, v in kwargs.items():
+            setattr(value, k, v)
+        return value
+
+    def setattr(self, target, name=SENTINEL, value=SENTINEL, **kwargs):
+        # alias to __call__ with the interface of pytest.monkeypatch.setattr
+        if value is SENTINEL:
+            value, name = name, None
+        return self(target, value, name=name)
+
+    def setitem(self, dic, name, value=SENTINEL, new=MagicMock, **kwargs):
+        # same as pytest.monkeypatch.setattr but default value is MagicMock
+        value = self._value_or_mock(value, new, name, dic, **kwargs)
+        self.monkeypatch.setitem(dic, name, value)
+        return value
+
+    def modules(self, *mods):
+        modules = []
+        for mod in mods:
+            mod = mod.split('.')
+            modules.extend(reversed([
+                '.'.join(mod[:-i] if i else mod) for i in range(len(mod))
+            ]))
+        modules = sorted(set(modules))
+        return _wrap_context(module_context_manager(*modules), self.request)
+
+
+def _wrap_context(context, request):
+    ret = context.__enter__()
+
+    def fin():
+        context.__exit__(*sys.exc_info())
+    request.addfinalizer(fin)
+    return ret
+
+
+@pytest.fixture()
+def patching(monkeypatch, request):
+    """Monkeypath.setattr shortcut.
+    Example:
+        .. code-block:: python
+        >>> def test_foo(patching):
+        >>>     # execv value here will be mock.MagicMock by default.
+        >>>     execv = patching('os.execv')
+        >>>     patching('sys.platform', 'darwin')  # set concrete value
+        >>>     patching.setenv('DJANGO_SETTINGS_MODULE', 'x.settings')
+        >>>     # val will be of type mock.MagicMock by default
+        >>>     val = patching.setitem('path.to.dict', 'KEY')
+    """
+    return _patching(monkeypatch, request)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Extracted from #458 

Copy required pytest fixtures from Celery https://github.com/celery/celery/pull/7077

Tried to use the `patching` fixture directly from Celery in https://github.com/celery/django-celery-results/pull/461 but that doesn't work.