### PR TITLE
Add support for Django 5.1 and Python 3.13

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
         strategy:
             matrix:
                 python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.9" ]
-                django: [ "32", "42", "50" ]
+                django: [ "32", "42", "50", "51" ]
                 exclude:
                     - python-version: "3.11"
                       django: "32"
@@ -24,9 +24,15 @@ jobs:
                       django: "50"
                     - python-version: "pypy3.9"
                       django: "50"
+                    - python-version: "3.8"
+                      django: "51"
+                    - python-version: "3.9"
+                      django: "51"
+                    - python-version: "pypy3.9"
+                      django: "51"
                     - python-version: "3.12"
                       django: "32"
-                
+
         services:
             postgres:
                 image: postgres

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,9 +13,15 @@ jobs:
         runs-on: blacksmith-4vcpu-ubuntu-2204
         strategy:
             matrix:
-                python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.9" ]
+                python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.9" ]
                 django: [ "32", "42", "50", "51" ]
                 exclude:
+                    - python-version: "3.13"
+                      django: "32"
+                    - python-version: "3.13"
+                      django: "42"
+                    - python-version: "3.13"
+                      django: "50"
                     - python-version: "3.11"
                       django: "32"
                     - python-version: "3.8"

--- a/requirements/test-django51.txt
+++ b/requirements/test-django51.txt
@@ -1,0 +1,2 @@
+django>=5.1,<5.2
+psycopg>=3.1.8 # necessary due to https://docs.djangoproject.com/en/4.2/releases/4.2/#psycopg-3-support

--- a/requirements/test-django51.txt
+++ b/requirements/test-django51.txt
@@ -1,2 +1,2 @@
-django>=5.1,<5.2
+django>=5.1.3,<5.2
 psycopg>=3.1.8 # necessary due to https://docs.djangoproject.com/en/4.2/releases/4.2/#psycopg-3-support

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ classes = """
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Framework :: Django

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ classes = """
     Framework :: Django :: 4.1
     Framework :: Django :: 4.2
     Framework :: Django :: 5.0
+    Framework :: Django :: 5.1
     Operating System :: OS Independent
     Topic :: Communications
     Topic :: System :: Distributed Computing

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ classes = """
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Framework :: Django

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py312-django{50,42}
-    py311-django{50,42}
-    py310-django{50,42,32}
+    py312-django{51,50,42}
+    py311-django{51,50,42}
+    py310-django{51,50,42,32}
     py39-django{42,32}
     py38-django{42,32}
     pypy39-django{42,32}
@@ -18,6 +18,7 @@ DJANGO =
     3.2: django32
     4.2: django42
     5.0: django50
+    5.1: django51
 
 [testenv]
 deps=
@@ -30,6 +31,7 @@ deps=
     django32: -r{toxinidir}/requirements/test-django32.txt
     django42: -r{toxinidir}/requirements/test-django42.txt
     django50: -r{toxinidir}/requirements/test-django50.txt
+    django51: -r{toxinidir}/requirements/test-django51.txt
 
     cov,integration: -r{toxinidir}/requirements/test-django.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist =
+    py313-django{51}
     py312-django{51,50,42}
     py311-django{51,50,42}
     py310-django{51,50,42,32}

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py312-django{42,50}
-    py311-django{42,50}
-    py310-django{42,50,32}
+    py312-django{50,42}
+    py311-django{50,42}
+    py310-django{50,42,32}
     py39-django{42,32}
     py38-django{42,32}
     pypy39-django{42,32}


### PR DESCRIPTION
I've lost track with https://github.com/celery/django-celery-results/pull/458 so re-opening this to add support for newer versions, without dropping anything yet. 

- [x] Add Django 5.1
- [x] Add Python 3.13

Fix #420 