### PR TITLE
Set Task Shadow Names as the Primary Task Name

### DIFF
--- a/django_celery_results/backends/database.py
+++ b/django_celery_results/backends/database.py
@@ -88,12 +88,14 @@ class DatabaseBackend(BaseDictBackend):
                 _, _, task_kwargs = self.encode_content(task_kwargs)
 
             periodic_task_name = getattr(request, 'periodic_task_name', None)
+            shadow_task_name = getattr(request, 'shadow_task_name', None)
+            task_name = shadow_task_name or getattr(request, 'task_name', None)
 
             extended_props.update({
                 'periodic_task_name': periodic_task_name,
                 'task_args': task_args,
                 'task_kwargs': task_kwargs,
-                'task_name': getattr(request, 'task', None),
+                'task_name': task_name,
                 'traceback': traceback,
                 'worker': getattr(request, 'hostname', None),
             })


### PR DESCRIPTION
Celery tasks have the `shadow_name` property used to define a custom name for tasks.
When a task has multiple executions, it becomes challenging to find their task results as they share the same task names, and the task IDs are usually UUIDs. Shadow names are useful to filter and identify results for monitoring.

This PR sets the shadow name as the primary choice for the `TaskResult.task_name` property. If it's not set, the default `task_name` will be used.