### PR TITLE
Use proper network name for postgres container

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -20,7 +20,7 @@ services:
         volumes:
             - postgres_data:/var/lib/postgresql/data
         networks:
-            jazzband:
+            celery:
                 aliases:
                     - dcr-postgres
 


### PR DESCRIPTION
`jazzband` isn't set up as network, but the postgres container uses it, while all other things are using `celery` as network name.