### PR TITLE
fix: error when registering TaskResultAdmin on proxy model

### DIFF
--- a/django_celery_results/admin.py
+++ b/django_celery_results/admin.py
@@ -64,7 +64,7 @@ class TaskResultAdmin(admin.ModelAdmin):
             return self.readonly_fields
         else:
             return list({
-                field.name for field in self.opts.local_fields
+                field.name for field in self.model._meta.fields
             })
 
 


### PR DESCRIPTION
Closes #394

I have tested using `field.name for field in self.model._meta.fields` on both the original model and the proxy model, and it works as expected.