### PR TITLE
Update Python versions in test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
         runs-on: blacksmith-4vcpu-ubuntu-2204
         strategy:
             matrix:
-                python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.10" ]
+                python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.10" ]
                 django: [ "32", "42", "51", "52" ]
                 exclude:
                     - python-version: "3.13"
@@ -22,12 +22,8 @@ jobs:
                       django: "42"
                     - python-version: "3.11"
                       django: "32"
-                    - python-version: "3.8"
-                      django: "52"
                     - python-version: "3.9"
                       django: "52"
-                    - python-version: "3.8"
-                      django: "51"
                     - python-version: "3.9"
                       django: "51"
                     - python-version: "3.12"


### PR DESCRIPTION
Removed Python 3.8 from the testing matrix and adjusted exclusions accordingly.