### PR TITLE
Fix test_database AttributeError on ignore_result with Celery 5.x

### DIFF
--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -52,6 +52,7 @@ class test_DatabaseBackend:
             sent_event = {}
         else:
             headers, properties, body, sent_event = msg
+        headers.setdefault('ignore_result', False)
         context = Context(
             headers=headers,
             properties=properties,


### PR DESCRIPTION
The protocol 1 test requests are built via hybrid_to_proto2() which does not include 'ignore_result' in the message headers. Celery 5.x's Request.__init__ reads 'ignore_result' from the headers and, when absent, falls back to self._task.ignore_result. Since these tests pass the task name rather than a task object, it causes an error:

    AttributeError: 'str' object has no attribute 'ignore_result'

Set the 'ignore_result' header to False in _create_request() so the fallback is never use. This is a no-op for protocol 2 (which already sets the header) and keeps request.task as the 'my_task' string, preserving the existing task_name assertions.

Closes: #508