### PR TITLE
Add retries and queue fields to result_extended (#513)

### DIFF
--- a/django_celery_results/admin.py
+++ b/django_celery_results/admin.py
@@ -24,9 +24,9 @@ class TaskResultAdmin(admin.ModelAdmin):
     model = TaskResult
     date_hierarchy = 'date_done'
     list_display = ('task_id', 'periodic_task_name', 'task_name', 'date_done',
-                    'status', 'worker')
+                    'status', 'worker', 'queue', 'retries')
     list_filter = ('status', 'date_done', 'periodic_task_name', 'task_name',
-                   'worker')
+                   'worker', 'queue', 'retries')
     readonly_fields = ('date_created', 'date_started', 'date_done',
                        'result', 'meta')
     search_fields = ('task_name', 'task_id', 'status', 'task_args',
@@ -39,6 +39,8 @@ class TaskResultAdmin(admin.ModelAdmin):
                 'periodic_task_name',
                 'status',
                 'worker',
+                'queue',
+                'retries',
                 'content_type',
                 'content_encoding',
             ),

--- a/django_celery_results/backends/database.py
+++ b/django_celery_results/backends/database.py
@@ -63,6 +63,8 @@ class DatabaseBackend(BaseDictBackend):
             'task_name': None,
             'traceback': None,
             'worker': None,
+            'queue': None,
+            'retries': None,
         }
         if request and self.app.conf.find_value_for_key('extended', 'result'):
 
@@ -96,6 +98,10 @@ class DatabaseBackend(BaseDictBackend):
                 'task_name': getattr(request, 'task', None),
                 'traceback': traceback,
                 'worker': getattr(request, 'hostname', None),
+                'retries': getattr(request, 'retries', None),
+                'queue': request.delivery_info.get('routing_key')
+                if hasattr(request, 'delivery_info') and request.delivery_info
+                else None,
             })
 
         return extended_props

--- a/django_celery_results/managers.py
+++ b/django_celery_results/managers.py
@@ -125,8 +125,8 @@ class TaskResultManager(ResultManager):
                      traceback=None, meta=None,
                      periodic_task_name=None,
                      task_name=None, task_args=None, task_kwargs=None,
-                     worker=None, queue=None, retries=None,
-                     using=None, **kwargs):
+                     worker=None, using=None, queue=None, retries=None,
+                     **kwargs):
         """Store the result and status of a task.
 
         Arguments:

--- a/django_celery_results/managers.py
+++ b/django_celery_results/managers.py
@@ -125,7 +125,8 @@ class TaskResultManager(ResultManager):
                      traceback=None, meta=None,
                      periodic_task_name=None,
                      task_name=None, task_args=None, task_kwargs=None,
-                     worker=None, using=None, **kwargs):
+                     worker=None, queue=None, retries=None,
+                     using=None, **kwargs):
         """Store the result and status of a task.
 
         Arguments:
@@ -141,6 +142,8 @@ class TaskResultManager(ResultManager):
             status (str): Task status.  See :mod:`celery.states` for a list of
                 possible status values.
             worker (str): Worker that executes the task.
+            queue (str): Queue the task was sent to.
+            retries (int): Number of times the task has been retried.
             using (str): Django database connection to use.
             traceback (str): The traceback string taken at the point of
                 exception (only passed if the task failed).
@@ -165,7 +168,9 @@ class TaskResultManager(ResultManager):
             'task_name': task_name,
             'task_args': task_args,
             'task_kwargs': task_kwargs,
-            'worker': worker
+            'worker': worker,
+            'queue': queue,
+            'retries': retries,
         }
         if 'date_started' in kwargs:
             fields['date_started'] = kwargs['date_started']

--- a/django_celery_results/migrations/0015_taskresult_retries_queue.py
+++ b/django_celery_results/migrations/0015_taskresult_retries_queue.py
@@ -1,0 +1,32 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("django_celery_results", "0014_alter_taskresult_status"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="taskresult",
+            name="queue",
+            field=models.CharField(
+                default=None,
+                help_text="Queue the task was sent to",
+                max_length=255,
+                null=True,
+                verbose_name="Queue",
+            ),
+        ),
+        migrations.AddField(
+            model_name="taskresult",
+            name="retries",
+            field=models.IntegerField(
+                default=None,
+                help_text="Number of times the task has been retried",
+                null=True,
+                verbose_name="Retries",
+            ),
+        ),
+    ]

--- a/django_celery_results/models.py
+++ b/django_celery_results/models.py
@@ -57,6 +57,16 @@ class TaskResult(models.Model):
         max_length=100, default=None, null=True,
         verbose_name=_('Worker'), help_text=_('Worker that executes the task')
     )
+    queue = models.CharField(
+        max_length=255, default=None, null=True,
+        verbose_name=_('Queue'),
+        help_text=_('Queue the task was sent to')
+    )
+    retries = models.IntegerField(
+        default=None, null=True,
+        verbose_name=_('Retries'),
+        help_text=_('Number of times the task has been retried')
+    )
     content_type = models.CharField(
         max_length=128,
         verbose_name=_('Result Content Type'),
@@ -129,7 +139,9 @@ class TaskResult(models.Model):
             'date_done': self.date_done,
             'traceback': self.traceback,
             'meta': self.meta,
-            'worker': self.worker
+            'worker': self.worker,
+            'queue': self.queue,
+            'retries': self.retries,
         }
 
     def __str__(self):

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -791,6 +791,8 @@ class test_DatabaseBackend:
         request.kwargsrepr = "kwargsrepr"
         request.hostname = "celery@ip-0-0-0-0"
         request.periodic_task_name = "my_periodic_task"
+        request.retries = 0
+        request.delivery_info = {}
         request.ignore_result = False
         result = {"foo": "baz"}
 
@@ -841,6 +843,8 @@ class test_DatabaseBackend:
         request.kwargsrepr = "kwargsrepr"
         request.hostname = "celery@ip-0-0-0-0"
         request.periodic_task_name = "my_periodic_task"
+        request.retries = 0
+        request.delivery_info = {}
         request.ignore_result = False
         request.chord.id = cid
         result = {"foo": "baz"}
@@ -887,6 +891,8 @@ class test_DatabaseBackend:
         request.kwargsrepr = "kwargsrepr"
         request.hostname = "celery@ip-0-0-0-0"
         request.periodic_task_name = "my_periodic_task"
+        request.retries = 0
+        request.delivery_info = {}
         request.chord.id = cid
         result = {"foo": "baz"}
 
@@ -950,11 +956,49 @@ class test_DatabaseBackend:
         assert mindb.get('task_name') is None
         assert mindb.get('task_args') is None
         assert mindb.get('task_kwargs') is None
+        assert mindb.get('worker') is None
+        assert mindb.get('retries') is None
+        assert mindb.get('queue') is None
 
         # check task_result object
         tr = TaskResult.objects.get(task_id=tid2)
         assert tr.task_args is None
         assert tr.task_kwargs is None
+        assert tr.worker is None
+        assert tr.retries is None
+        assert tr.queue is None
+
+    def test_backend_result_extended_retries_and_queue(self):
+        tid2 = uuid()
+        request = Context(
+            id=tid2,
+            task='my_task',
+            args=['a', 1, True],
+            kwargs={'c': 6, 'd': 'e', 'f': False},
+            argsrepr=None,
+            kwargsrepr=None,
+            hostname='celery@ip-0-0-0-0',
+            retries=3,
+            delivery_info={'routing_key': 'celery'},
+        )
+        result = 'foo'
+
+        self.b.mark_as_done(tid2, result, request=request)
+
+        mindb = self.b.get_task_meta(tid2)
+
+        # check meta data
+        assert mindb.get('result') == 'foo'
+        assert mindb.get('task_name') == 'my_task'
+        assert mindb.get('worker') == 'celery@ip-0-0-0-0'
+        assert mindb.get('retries') == 3
+        assert mindb.get('queue') == 'celery'
+
+        # check task_result object
+        tr = TaskResult.objects.get(task_id=tid2)
+        assert tr.worker == 'celery@ip-0-0-0-0'
+        assert tr.retries == 3
+        assert tr.queue == 'celery'
 
     def test_custom_state(self):
         tid = uuid()
@@ -1033,6 +1077,8 @@ class ChordPartReturnTestCase(TransactionTestCase):
             request.kwargsrepr = "kwargsrepr"
             request.hostname = "celery@ip-0-0-0-0"
             request.periodic_task_name = "my_periodic_task"
+            request.retries = 0
+            request.delivery_info = {}
             request.ignore_result = False
             result = {"foo": "baz"}
 


### PR DESCRIPTION
Fixes #513.

Support all fields in `result_extended` that celery's native database backend exposes. `worker` was already stored; this adds `retries` and `queue`.

- Add `queue` and `retries` columns to `TaskResult` model (+ migration)
- Populate them from the task request (`request.retries`, `request.delivery_info['routing_key']`)
- Surface them in the admin
- Tests